### PR TITLE
Use custom options on NativeLibraryBuilder

### DIFF
--- a/src/Core/Silk.NET.Core/Loader/LibraryLoader.cs
+++ b/src/Core/Silk.NET.Core/Loader/LibraryLoader.cs
@@ -21,7 +21,7 @@ namespace Silk.NET.Core.Loader
 
         static LibraryLoader()
         {
-            _builder = new NativeLibraryBuilder();
+            _builder = new NativeLibraryBuilder(Options);
         }
 
         public static T1 Load<T1>(SearchPathContainer nameContainer) where T1 : NativeAPI


### PR DESCRIPTION
# Summary of the PR
Fixes `SymbolLoadingException`.

# Related issues, Discord discussions, or proposals
Links go here.

# Further Comments
We wouldn't have encountered this if NVIDIA was actually compliant with the OpenGL 4.6 spec - `glPolygonOffsetClamp` wasn't implemented by driver 390. Will complain to them in my own time.