### PR TITLE
Binder fixes

### DIFF
--- a/build/binder_scripts/build.json
+++ b/build/binder_scripts/build.json
@@ -1,1 +1,6 @@
-[]
+[
+    {
+        "Task": "bind",
+        "Args": ["-i", "../binder_specifications/OpenGL.json", "../binder_specifications/GLES.json", "../binder_specifications/OpenGL (Compatibility Profile).json", "-o", "../../src", "-l", "../LICENSE_HEADER.txt", "-p", "../props/bindings.props"]
+    }
+]

--- a/examples/BlankWindow/BlankWindow.csproj
+++ b/examples/BlankWindow/BlankWindow.csproj
@@ -6,6 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <ProjectReference Include="..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
       <ProjectReference Include="..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 

--- a/examples/BlankWindow/BlankWindow.csproj
+++ b/examples/BlankWindow/BlankWindow.csproj
@@ -6,7 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\..\src\OpenGL\Silk.NET.OpenGL\Silk.NET.OpenGL.csproj" />
       <ProjectReference Include="..\..\src\Windowing\Silk.NET.Windowing\Silk.NET.Windowing.csproj" />
     </ItemGroup>
 

--- a/examples/BlankWindow/Program.cs
+++ b/examples/BlankWindow/Program.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Drawing;
 using System.Threading;
-using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
 using Silk.NET.Windowing.Common;
 
@@ -14,7 +13,6 @@ namespace BlankWindow
 {
     internal class Program
     {
-        public static GL gl;
         public static IWindow window;
 
         private static void Main()
@@ -46,8 +44,6 @@ namespace BlankWindow
             window.VSync = VSyncMode.Off;
 
             Console.WriteLine($"Entry thread is {Thread.CurrentThread.ManagedThreadId}");
-
-            gl = GL.GetApi();
 
             window.Run();
         }

--- a/examples/BlankWindow/Program.cs
+++ b/examples/BlankWindow/Program.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Drawing;
 using System.Threading;
+using Silk.NET.OpenGL;
 using Silk.NET.Windowing;
 using Silk.NET.Windowing.Common;
 
@@ -13,6 +14,7 @@ namespace BlankWindow
 {
     internal class Program
     {
+        public static GL gl;
         public static IWindow window;
 
         private static void Main()
@@ -44,6 +46,8 @@ namespace BlankWindow
             window.VSync = VSyncMode.Off;
 
             Console.WriteLine($"Entry thread is {Thread.CurrentThread.ManagedThreadId}");
+
+            gl = GL.GetApi();
 
             window.Run();
         }

--- a/generator.bat
+++ b/generator.bat
@@ -1,2 +1,2 @@
 if "%1"=="" ( set "AddArgs=build/binder_scripts/build.json" ) else ( set "AddArgs=" )
-dotnet run -p src/BuildTools/BuildTools.csproj %AddArgs%%*
+dotnet run -p src/Core/BuildTools/BuildTools.csproj %AddArgs%%*

--- a/generator.bat
+++ b/generator.bat
@@ -1,2 +1,2 @@
 if "%1"=="" ( set "AddArgs=build/binder_scripts/build.json" ) else ( set "AddArgs=" )
-dotnet run -p src/Core/BuildTools/BuildTools.csproj %AddArgs%%*
+dotnet run --configuration Release -p src/Core/BuildTools/BuildTools.csproj %AddArgs%%*

--- a/generator.sh
+++ b/generator.sh
@@ -6,4 +6,4 @@ else
     export AddArgs=$1;
 fi
 
-dotnet run -p src/Core/BuildTools/BuildTools.csproj $AddArgs
+dotnet run --configuration Release -p src/Core/BuildTools/BuildTools.csproj $AddArgs

--- a/generator.sh
+++ b/generator.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -z $1 ]; then
+    export AddArgs="build/binder_scripts/build.json";
+else
+    export AddArgs=$1;
+fi
+
+dotnet run -p src/Core/BuildTools/BuildTools.csproj $AddArgs

--- a/generator.sh
+++ b/generator.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-if [ -z $1 ]; then
+if [ -z "$@" ]; then
     export AddArgs="build/binder_scripts/build.json";
 else
-    export AddArgs=$1;
+    export AddArgs="$@"
 fi
 
 dotnet run --configuration Release -p src/Core/BuildTools/BuildTools.csproj $AddArgs

--- a/pack.bat
+++ b/pack.bat
@@ -1,1 +1,1 @@
-dotnet pack -o build/output_packages
+dotnet pack --configuration Release -o build/output_packages

--- a/pack.sh
+++ b/pack.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+dotnet pack -o build/output_packages

--- a/pack.sh
+++ b/pack.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-dotnet pack -o build/output_packages
+dotnet pack --configuration Release -o build/output_packages

--- a/src/Core/BuildTools/Bind/BindOptions.cs
+++ b/src/Core/BuildTools/Bind/BindOptions.cs
@@ -6,7 +6,7 @@
 using System.Collections.Generic;
 using CommandLine;
 
-namespace Generator.Bind
+namespace Silk.NET.BuildTools.Bind
 {
     /// <summary>
     /// Holds command-line arguments, parsed from the command line.

--- a/src/Core/BuildTools/Bind/Binder.cs
+++ b/src/Core/BuildTools/Bind/Binder.cs
@@ -6,12 +6,11 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
-using Generator.Common;
 using MoreLinq.Extensions;
 using Newtonsoft.Json;
+using Silk.NET.BuildTools.Common;
 
-namespace Generator.Bind
+namespace Silk.NET.BuildTools.Bind
 {
     /// <summary>
     /// The entry point for the bindings writer.

--- a/src/Core/BuildTools/Bind/Overloading/IFunctionOverloader.cs
+++ b/src/Core/BuildTools/Bind/Overloading/IFunctionOverloader.cs
@@ -4,10 +4,10 @@
 // of the MIT license. See the LICENSE file for details.
 
 using System.Collections.Generic;
-using Generator.Common.Functions;
 using JetBrains.Annotations;
+using Silk.NET.BuildTools.Common.Functions;
 
-namespace Generator.Bind.Overloading
+namespace Silk.NET.BuildTools.Bind.Overloading
 {
     /// <summary>
     /// Represents a class that can create a set of overloads from a given base signature.

--- a/src/Core/BuildTools/Bind/Overloading/Overload.cs
+++ b/src/Core/BuildTools/Bind/Overloading/Overload.cs
@@ -4,9 +4,9 @@
 // of the MIT license. See the LICENSE file for details.
 
 using System.Text;
-using Generator.Common.Functions;
+using Silk.NET.BuildTools.Common.Functions;
 
-namespace Generator.Bind.Overloading
+namespace Silk.NET.BuildTools.Bind.Overloading
 {
     public class Overload
     {

--- a/src/Core/BuildTools/Bind/Overloading/Overloader.cs
+++ b/src/Core/BuildTools/Bind/Overloading/Overloader.cs
@@ -4,9 +4,9 @@
 // of the MIT license. See the LICENSE file for details.
 
 using System.Collections.Generic;
-using Generator.Common;
+using Silk.NET.BuildTools.Common;
 
-namespace Generator.Bind.Overloading
+namespace Silk.NET.BuildTools.Bind.Overloading
 {
     public static class Overloader
     {

--- a/src/Core/BuildTools/Bind/ProfileWriter.cs
+++ b/src/Core/BuildTools/Bind/ProfileWriter.cs
@@ -249,6 +249,7 @@ namespace Silk.NET.BuildTools.Bind
                 if (!File.Exists(Path.Combine(folder, profile.ClassName + ".cs")))
                 {
                     sw = new StreamWriter(Path.Combine(folder, profile.ClassName + ".cs"));
+                    sw.WriteLine("using System;");
                     sw.WriteLine("using Silk.NET.Core.Loader;");
                     sw.WriteLine("using Silk.NET.Core.Native;");
                     sw.WriteLine();
@@ -267,7 +268,7 @@ namespace Silk.NET.BuildTools.Bind
                     sw.WriteLine($"             ext = LibraryLoader<{profile.ClassName}>.Load<T>(this);");
                     sw.WriteLine("             return ext != null;");
                     sw.WriteLine("        }");
-                    sw.WriteLine("        public bool IsExtensionPresent(string extension)");
+                    sw.WriteLine("        public override bool IsExtensionPresent(string extension)");
                     sw.WriteLine("        {");
                     sw.WriteLine("            throw new NotImplementedException();");
                     sw.WriteLine("        }");

--- a/src/Core/BuildTools/Bind/ProfileWriter.cs
+++ b/src/Core/BuildTools/Bind/ProfileWriter.cs
@@ -267,6 +267,10 @@ namespace Silk.NET.BuildTools.Bind
                     sw.WriteLine($"             ext = LibraryLoader<{profile.ClassName}>.Load<T>(this);");
                     sw.WriteLine("             return ext != null;");
                     sw.WriteLine("        }");
+                    sw.WriteLine("        public bool IsExtensionPresent(string extension)");
+                    sw.WriteLine("        {");
+                    sw.WriteLine("            throw new NotImplementedException();");
+                    sw.WriteLine("        }");
                     sw.WriteLine("    }");
                     sw.WriteLine("}");
                     sw.WriteLine();

--- a/src/Core/BuildTools/Bind/ProfileWriter.cs
+++ b/src/Core/BuildTools/Bind/ProfileWriter.cs
@@ -144,7 +144,7 @@ namespace Silk.NET.BuildTools.Bind
             sw.WriteLine("namespace " + profile.Namespace + project.Namespace);
             sw.WriteLine("{");
             var names = project.Interfaces.Select(x => x.Value.Name).ToArray();
-            sw.Write("    internal interface I" + profile.ClassName + " : " + names[0]);
+            sw.Write("    public interface I" + profile.ClassName + " : " + names[0]);
             for (var i = 1; i < names.Length; i++)
             {
                 sw.WriteLine(",");

--- a/src/Core/BuildTools/Bind/ProfileWriter.cs
+++ b/src/Core/BuildTools/Bind/ProfileWriter.cs
@@ -7,7 +7,6 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using Generator.Common;
 using MoreLinq.Extensions;
 using Enum = Generator.Common.Enums.Enum;
@@ -98,7 +97,7 @@ namespace Generator.Bind
                 sw.WriteLine("    " + attr);
             }
 
-            sw.WriteLine("    internal interface " + @interface.Name);
+            sw.WriteLine("    public interface " + @interface.Name);
             sw.Write("    {");
             for (var index = 0; index < @interface.Functions.Count; index++)
             {

--- a/src/Core/BuildTools/Bind/ProfileWriter.cs
+++ b/src/Core/BuildTools/Bind/ProfileWriter.cs
@@ -7,11 +7,11 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using Generator.Common;
 using MoreLinq.Extensions;
-using Enum = Generator.Common.Enums.Enum;
+using Silk.NET.BuildTools.Common;
+using Enum = Silk.NET.BuildTools.Common.Enums.Enum;
 
-namespace Generator.Bind
+namespace Silk.NET.BuildTools.Bind
 {
     /// <summary>
     /// Contains methods for writing profiles to disk.

--- a/src/Core/BuildTools/Common/Attribute.cs
+++ b/src/Core/BuildTools/Common/Attribute.cs
@@ -6,7 +6,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Generator.Common
+namespace Silk.NET.BuildTools.Common
 {
     /// <summary>
     /// Represents a C# attribute.

--- a/src/Core/BuildTools/Common/Builders/FunctionSignatureBuilder.cs
+++ b/src/Core/BuildTools/Common/Builders/FunctionSignatureBuilder.cs
@@ -5,10 +5,10 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Generator.Common.Functions;
 using JetBrains.Annotations;
+using Silk.NET.BuildTools.Common.Functions;
 
-namespace Generator.Common.Builders
+namespace Silk.NET.BuildTools.Common.Builders
 {
     /// <summary>
     /// Acts as a builder for new instances of <see cref="FunctionSignature" />s, based on existing instances.

--- a/src/Core/BuildTools/Common/Builders/ParameterSignatureBuilder.cs
+++ b/src/Core/BuildTools/Common/Builders/ParameterSignatureBuilder.cs
@@ -3,10 +3,10 @@
 // You may modify and distribute Silk.NET under the terms
 // of the MIT license. See the LICENSE file for details.
 
-using Generator.Common.Functions;
 using JetBrains.Annotations;
+using Silk.NET.BuildTools.Common.Functions;
 
-namespace Generator.Common.Builders
+namespace Silk.NET.BuildTools.Common.Builders
 {
     /// <summary>
     /// Acts as a builder for new instances of <see cref="ParameterSignature" />s, based on existing instances.

--- a/src/Core/BuildTools/Common/Builders/TypeSignatureBuilder.cs
+++ b/src/Core/BuildTools/Common/Builders/TypeSignatureBuilder.cs
@@ -3,10 +3,10 @@
 // You may modify and distribute Silk.NET under the terms
 // of the MIT license. See the LICENSE file for details.
 
-using Generator.Common.Functions;
 using JetBrains.Annotations;
+using Silk.NET.BuildTools.Common.Functions;
 
-namespace Generator.Common.Builders
+namespace Silk.NET.BuildTools.Common.Builders
 {
     /// <summary>
     /// Acts as a builder for new instances of <see cref="TypeSignature" />s, based on existing instances.

--- a/src/Core/BuildTools/Common/Enums/Enum.cs
+++ b/src/Core/BuildTools/Common/Enums/Enum.cs
@@ -5,7 +5,7 @@
 
 using System.Collections.Generic;
 
-namespace Generator.Common.Enums
+namespace Silk.NET.BuildTools.Common.Enums
 {
     /// <summary>
     /// Represents a C# enum.

--- a/src/Core/BuildTools/Common/Enums/Token.cs
+++ b/src/Core/BuildTools/Common/Enums/Token.cs
@@ -5,7 +5,7 @@
 
 using System.Collections.Generic;
 
-namespace Generator.Common.Enums
+namespace Silk.NET.BuildTools.Common.Enums
 {
     /// <summary>
     /// Represents an enum token.

--- a/src/Core/BuildTools/Common/Functions/Count.cs
+++ b/src/Core/BuildTools/Common/Functions/Count.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 
-namespace Generator.Common.Functions
+namespace Silk.NET.BuildTools.Common.Functions
 {
     /// <summary>
     /// Represents a computed or static element count of a parameter. A computed parameter varies its count based on the

--- a/src/Core/BuildTools/Common/Functions/Count.cs
+++ b/src/Core/BuildTools/Common/Functions/Count.cs
@@ -145,12 +145,7 @@ namespace Silk.NET.BuildTools.Common.Functions
                 return $"COMPSIZE({string.Join(", ", ComputedFromNames)})";
             }
 
-            if (IsReference)
-            {
-                return $"valueof({ValueReference.Name})";
-            }
-
-            return StaticCount.ToString();
+            return IsReference ? $"valueof({ValueReference.Name})" : StaticCount.ToString();
         }
     }
 }

--- a/src/Core/BuildTools/Common/Functions/FlowDirection.cs
+++ b/src/Core/BuildTools/Common/Functions/FlowDirection.cs
@@ -3,7 +3,7 @@
 // You may modify and distribute Silk.NET under the terms
 // of the MIT license. See the LICENSE file for details.
 
-namespace Generator.Common.Functions
+namespace Silk.NET.BuildTools.Common.Functions
 {
     /// <summary>
     /// Enumerates the possible flows of a parameter (ie. is this parameter

--- a/src/Core/BuildTools/Common/Functions/Function.cs
+++ b/src/Core/BuildTools/Common/Functions/Function.cs
@@ -231,7 +231,7 @@ namespace Silk.NET.BuildTools.Common.Functions
                 return true;
             }
 
-            return obj.GetType() == GetType() && Equals((Function) obj);
+            return obj is Function function && Equals(function);
         }
 
         public override int GetHashCode()

--- a/src/Core/BuildTools/Common/Functions/Function.cs
+++ b/src/Core/BuildTools/Common/Functions/Function.cs
@@ -10,7 +10,7 @@ using System.Text;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 
-namespace Generator.Common.Functions
+namespace Silk.NET.BuildTools.Common.Functions
 {
     /// <summary>
     /// Represents a C# function.

--- a/src/Core/BuildTools/Common/Functions/Function.cs
+++ b/src/Core/BuildTools/Common/Functions/Function.cs
@@ -231,12 +231,7 @@ namespace Silk.NET.BuildTools.Common.Functions
                 return true;
             }
 
-            if (obj.GetType() != this.GetType())
-            {
-                return false;
-            }
-
-            return Equals((Function) obj);
+            return obj.GetType() == GetType() && Equals((Function) obj);
         }
 
         public override int GetHashCode()

--- a/src/Core/BuildTools/Common/Functions/GenericTypeParameter.cs
+++ b/src/Core/BuildTools/Common/Functions/GenericTypeParameter.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Generator.Common.Functions
+namespace Silk.NET.BuildTools.Common.Functions
 {
     /// <summary>
     /// Represents a C# generic type parameter.

--- a/src/Core/BuildTools/Common/Functions/GenericTypeParameter.cs
+++ b/src/Core/BuildTools/Common/Functions/GenericTypeParameter.cs
@@ -61,7 +61,7 @@ namespace Silk.NET.BuildTools.Common.Functions
                 return true;
             }
 
-            return obj.GetType() == GetType() && Equals((GenericTypeParameter) obj);
+            return obj is GenericTypeParameter parameter && Equals(parameter);
         }
 
         public override int GetHashCode()

--- a/src/Core/BuildTools/Common/Functions/GenericTypeParameter.cs
+++ b/src/Core/BuildTools/Common/Functions/GenericTypeParameter.cs
@@ -61,12 +61,7 @@ namespace Silk.NET.BuildTools.Common.Functions
                 return true;
             }
 
-            if (obj.GetType() != this.GetType())
-            {
-                return false;
-            }
-
-            return Equals((GenericTypeParameter) obj);
+            return obj.GetType() == GetType() && Equals((GenericTypeParameter) obj);
         }
 
         public override int GetHashCode()

--- a/src/Core/BuildTools/Common/Functions/Parameter.cs
+++ b/src/Core/BuildTools/Common/Functions/Parameter.cs
@@ -5,7 +5,7 @@
 
 using System;
 
-namespace Generator.Common.Functions
+namespace Silk.NET.BuildTools.Common.Functions
 {
     /// <summary>
     /// Represents a parameter of a C# function.

--- a/src/Core/BuildTools/Common/Functions/Parameter.cs
+++ b/src/Core/BuildTools/Common/Functions/Parameter.cs
@@ -60,7 +60,7 @@ namespace Silk.NET.BuildTools.Common.Functions
                 return true;
             }
 
-            return obj.GetType() == GetType() && Equals((GenericTypeParameter) obj);
+            return obj is Parameter && Equals((GenericTypeParameter) obj);
         }
 
         public override int GetHashCode()

--- a/src/Core/BuildTools/Common/Functions/Parameter.cs
+++ b/src/Core/BuildTools/Common/Functions/Parameter.cs
@@ -60,12 +60,7 @@ namespace Silk.NET.BuildTools.Common.Functions
                 return true;
             }
 
-            if (obj.GetType() != this.GetType())
-            {
-                return false;
-            }
-
-            return Equals((Parameter) obj);
+            return obj.GetType() == GetType() && Equals((GenericTypeParameter) obj);
         }
 
         public override int GetHashCode()

--- a/src/Core/BuildTools/Common/Functions/Parameter.cs
+++ b/src/Core/BuildTools/Common/Functions/Parameter.cs
@@ -60,7 +60,7 @@ namespace Silk.NET.BuildTools.Common.Functions
                 return true;
             }
 
-            return obj is Parameter && Equals((GenericTypeParameter) obj);
+            return obj is Parameter parameter && Equals(parameter);
         }
 
         public override int GetHashCode()

--- a/src/Core/BuildTools/Common/Functions/Type.cs
+++ b/src/Core/BuildTools/Common/Functions/Type.cs
@@ -6,7 +6,7 @@
 using System;
 using Newtonsoft.Json;
 
-namespace Generator.Common.Functions
+namespace Silk.NET.BuildTools.Common.Functions
 {
     /// <summary>
     /// Represents a C# type signature.

--- a/src/Core/BuildTools/Common/Functions/Type.cs
+++ b/src/Core/BuildTools/Common/Functions/Type.cs
@@ -103,7 +103,7 @@ namespace Silk.NET.BuildTools.Common.Functions
                 return true;
             }
 
-            return obj.GetType() == GetType() && Equals((GenericTypeParameter) obj);
+            return obj is Type && Equals((GenericTypeParameter) obj);
         }
 
         public override int GetHashCode()

--- a/src/Core/BuildTools/Common/Functions/Type.cs
+++ b/src/Core/BuildTools/Common/Functions/Type.cs
@@ -103,7 +103,7 @@ namespace Silk.NET.BuildTools.Common.Functions
                 return true;
             }
 
-            return obj is Type && Equals((GenericTypeParameter) obj);
+            return obj is Type type && Equals(type);
         }
 
         public override int GetHashCode()

--- a/src/Core/BuildTools/Common/Functions/Type.cs
+++ b/src/Core/BuildTools/Common/Functions/Type.cs
@@ -103,12 +103,7 @@ namespace Silk.NET.BuildTools.Common.Functions
                 return true;
             }
 
-            if (obj.GetType() != this.GetType())
-            {
-                return false;
-            }
-
-            return Equals((Type) obj);
+            return obj.GetType() == GetType() && Equals((GenericTypeParameter) obj);
         }
 
         public override int GetHashCode()

--- a/src/Core/BuildTools/Common/Interface.cs
+++ b/src/Core/BuildTools/Common/Interface.cs
@@ -4,9 +4,9 @@
 // of the MIT license. See the LICENSE file for details.
 
 using System.Collections.Generic;
-using Generator.Common.Functions;
+using Silk.NET.BuildTools.Common.Functions;
 
-namespace Generator.Common
+namespace Silk.NET.BuildTools.Common
 {
     /// <summary>
     /// Represents an AdvancedDLSupport interface.

--- a/src/Core/BuildTools/Common/NameContainer.cs
+++ b/src/Core/BuildTools/Common/NameContainer.cs
@@ -3,7 +3,7 @@
 // You may modify and distribute Silk.NET under the terms
 // of the MIT license. See the LICENSE file for details.
 
-namespace Generator.Common
+namespace Silk.NET.BuildTools.Common
 {
     /// <summary>
     /// Represents a platform name container.

--- a/src/Core/BuildTools/Common/Profile.cs
+++ b/src/Core/BuildTools/Common/Profile.cs
@@ -6,7 +6,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
-namespace Generator.Common
+namespace Silk.NET.BuildTools.Common
 {
     /// <summary>
     /// Represents a subsystem as defined in GitHub issue #823.

--- a/src/Core/BuildTools/Common/Project.cs
+++ b/src/Core/BuildTools/Common/Project.cs
@@ -4,9 +4,9 @@
 // of the MIT license. See the LICENSE file for details.
 
 using System.Collections.Generic;
-using Generator.Common.Enums;
+using Silk.NET.BuildTools.Common.Enums;
 
-namespace Generator.Common
+namespace Silk.NET.BuildTools.Common
 {
     /// <summary>
     /// Represents a project, whether root or extension, containing <see cref="Interface" />s and <see cref="Enum" />s.

--- a/src/Core/BuildTools/Common/Utilities.cs
+++ b/src/Core/BuildTools/Common/Utilities.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 
-namespace Generator.Common
+namespace Silk.NET.BuildTools.Common
 {
     /// <summary>
     /// Various utilities for use by the tool.

--- a/src/Core/BuildTools/Convert/Baking/ProfileBakery.cs
+++ b/src/Core/BuildTools/Convert/Baking/ProfileBakery.cs
@@ -8,16 +8,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
-using Generator.Common;
-using Generator.Common.Enums;
-using Generator.Common.Functions;
-using Generator.Convert.Construction;
-using Generator.Convert.Documentation;
 using MoreLinq.Extensions;
 using Newtonsoft.Json;
+using Silk.NET.BuildTools.Common;
+using Silk.NET.BuildTools.Common.Enums;
+using Silk.NET.BuildTools.Common.Functions;
+using Silk.NET.BuildTools.Convert.Documentation;
 
-namespace Generator.Convert.Baking
+namespace Silk.NET.BuildTools.Convert.Baking
 {
     /// <summary>
     /// A collection of methods for baking/fusing APIs together.

--- a/src/Core/BuildTools/Convert/Baking/ProfileBakeryInformation.cs
+++ b/src/Core/BuildTools/Convert/Baking/ProfileBakeryInformation.cs
@@ -4,9 +4,9 @@
 // of the MIT license. See the LICENSE file for details.
 
 using System.Collections.Generic;
-using Generator.Common;
+using Silk.NET.BuildTools.Common;
 
-namespace Generator.Convert.Baking
+namespace Silk.NET.BuildTools.Convert.Baking
 {
     /// <summary>
     /// Represents information to be passed to the profile bakery (a script or recipe if you will).

--- a/src/Core/BuildTools/Convert/Baking/ProfileBakeryInformationBuilder.cs
+++ b/src/Core/BuildTools/Convert/Baking/ProfileBakeryInformationBuilder.cs
@@ -3,7 +3,7 @@
 // You may modify and distribute Silk.NET under the terms
 // of the MIT license. See the LICENSE file for details.
 
-namespace Generator.Convert.Baking
+namespace Silk.NET.BuildTools.Convert.Baking
 {
     /// <summary>
     /// A builder class for <see cref="ProfileBakeryInformation" />.

--- a/src/Core/BuildTools/Convert/Construction/EnumTokenComparer.cs
+++ b/src/Core/BuildTools/Convert/Construction/EnumTokenComparer.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Xml.Linq;
 
-namespace Generator.Convert.Construction
+namespace Silk.NET.BuildTools.Convert.Construction
 {
     /// <summary>
     /// An equality comparer that compares enum names.

--- a/src/Core/BuildTools/Convert/Construction/NameTrimmer.cs
+++ b/src/Core/BuildTools/Convert/Construction/NameTrimmer.cs
@@ -3,15 +3,12 @@
 // You may modify and distribute Silk.NET under the terms
 // of the MIT license. See the LICENSE file for details.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
-using Generator.Common.Functions;
-using Generator.Convert.Construction.Trimmers;
 using JetBrains.Annotations;
+using Silk.NET.BuildTools.Convert.Construction.Trimmers;
 
-namespace Generator.Convert.Construction
+namespace Silk.NET.BuildTools.Convert.Construction
 {
     /// <summary>
     /// A collection of functions for altering the endings of function names.

--- a/src/Core/BuildTools/Convert/Construction/NativeIdentifierTranslator.cs
+++ b/src/Core/BuildTools/Convert/Construction/NativeIdentifierTranslator.cs
@@ -8,11 +8,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using Generator.Common;
 using Humanizer;
 using JetBrains.Annotations;
+using Silk.NET.BuildTools.Common;
 
-namespace Generator.Convert.Construction
+namespace Silk.NET.BuildTools.Convert.Construction
 {
     /// <summary>
     /// Translates an identifier (a type name, a constant name, etc) into a .NET-style identifier.

--- a/src/Core/BuildTools/Convert/Construction/ParsingHelpers.cs
+++ b/src/Core/BuildTools/Convert/Construction/ParsingHelpers.cs
@@ -9,13 +9,13 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
-using Generator.Common.Functions;
-using Generator.Convert.XML;
 using JetBrains.Annotations;
 using Microsoft.CodeAnalysis.CSharp;
-using Type = Generator.Common.Functions.Type;
+using Silk.NET.BuildTools.Common.Functions;
+using Silk.NET.BuildTools.Convert.XML;
+using Type = Silk.NET.BuildTools.Common.Functions.Type;
 
-namespace Generator.Convert.Construction
+namespace Silk.NET.BuildTools.Convert.Construction
 {
     /// <summary>
     /// Shared functionality for the parsing classes.

--- a/src/Core/BuildTools/Convert/Construction/ProfileConstructorExtensions.cs
+++ b/src/Core/BuildTools/Convert/Construction/ProfileConstructorExtensions.cs
@@ -82,8 +82,7 @@ namespace Silk.NET.BuildTools.Convert.Construction
                 .Value
                 .Split(new[] {'|'}, StringSplitOptions.RemoveEmptyEntries);
             var functionExtensions = element.GetRequiredAttribute("extension").Value;
-
-            var functionVersion = ParsingHelpers.ParseVersion(element, defaultVersion: new Version(0, 0));
+            
             var functionDeprecationVersion = ParsingHelpers.ParseVersion(element, "deprecated");
 
             var parameters = ParseParameters(element);
@@ -137,7 +136,7 @@ namespace Silk.NET.BuildTools.Convert.Construction
                     out var computedCountParameterNames,
                     out var hasValueReference,
                     out var valueReferenceName,
-                    out var valueReferenceExpression
+                    out var _
                 );
 
                 if (hasComputedCount)

--- a/src/Core/BuildTools/Convert/Construction/ProfileConstructorExtensions.cs
+++ b/src/Core/BuildTools/Convert/Construction/ProfileConstructorExtensions.cs
@@ -10,15 +10,15 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
-using Generator.Common;
-using Generator.Common.Enums;
-using Generator.Common.Functions;
-using Generator.Convert.XML;
 using JetBrains.Annotations;
-using Attribute = Generator.Common.Attribute;
-using Enum = Generator.Common.Enums.Enum;
+using Silk.NET.BuildTools.Common;
+using Silk.NET.BuildTools.Common.Enums;
+using Silk.NET.BuildTools.Common.Functions;
+using Silk.NET.BuildTools.Convert.XML;
+using Attribute = Silk.NET.BuildTools.Common.Attribute;
+using Enum = Silk.NET.BuildTools.Common.Enums.Enum;
 
-namespace Generator.Convert.Construction
+namespace Silk.NET.BuildTools.Convert.Construction
 {
     /// <summary>
     /// A collection of extension methods for parsing and constructing profiles.

--- a/src/Core/BuildTools/Convert/Construction/Trimmers/DataTypeNameTrimmer.cs
+++ b/src/Core/BuildTools/Convert/Construction/Trimmers/DataTypeNameTrimmer.cs
@@ -5,10 +5,10 @@
 
 using System.Linq;
 using System.Text.RegularExpressions;
-using Generator.Common;
-using Generator.Common.Functions;
+using Silk.NET.BuildTools.Common;
+using Silk.NET.BuildTools.Common.Functions;
 
-namespace Generator.Convert.Construction.Trimmers
+namespace Silk.NET.BuildTools.Convert.Construction.Trimmers
 {
     /// <inheritdoc cref="ITrimmer{TTrimmable}" />
     /// <summary>

--- a/src/Core/BuildTools/Convert/Construction/Trimmers/ExtensionNameTrimmer.cs
+++ b/src/Core/BuildTools/Convert/Construction/Trimmers/ExtensionNameTrimmer.cs
@@ -5,10 +5,10 @@
 
 using System;
 using System.Text;
-using Generator.Common;
-using Generator.Common.Functions;
+using Silk.NET.BuildTools.Common;
+using Silk.NET.BuildTools.Common.Functions;
 
-namespace Generator.Convert.Construction.Trimmers
+namespace Silk.NET.BuildTools.Convert.Construction.Trimmers
 {
     /// <summary>
     /// Trims OpenGL extension names from OpenGL functions.

--- a/src/Core/BuildTools/Convert/Construction/Trimmers/ITrimmer.cs
+++ b/src/Core/BuildTools/Convert/Construction/Trimmers/ITrimmer.cs
@@ -5,7 +5,7 @@
 
 using JetBrains.Annotations;
 
-namespace Generator.Convert.Construction.Trimmers
+namespace Silk.NET.BuildTools.Convert.Construction.Trimmers
 {
     /// <summary>
     /// Represents a class that can trim the identifier for some type in some fashion.

--- a/src/Core/BuildTools/Convert/Construction/TypeMapper.cs
+++ b/src/Core/BuildTools/Convert/Construction/TypeMapper.cs
@@ -5,10 +5,10 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Generator.Common;
-using Generator.Common.Functions;
+using Silk.NET.BuildTools.Common;
+using Silk.NET.BuildTools.Common.Functions;
 
-namespace Generator.Convert.Construction
+namespace Silk.NET.BuildTools.Convert.Construction
 {
     /// <summary>
     /// A collection of methods for replacing type names using a dictionary.

--- a/src/Core/BuildTools/Convert/ConvertOptions.cs
+++ b/src/Core/BuildTools/Convert/ConvertOptions.cs
@@ -6,9 +6,9 @@
 using System.Collections.Generic;
 using CommandLine;
 using CommandLine.Text;
-using Generator.Convert.Baking;
+using Silk.NET.BuildTools.Convert.Baking;
 
-namespace Generator.Convert
+namespace Silk.NET.BuildTools.Convert
 {
     /// <summary>
     /// A container class used by <see cref="CommandLine.Parser" /> to parse command line arguments.

--- a/src/Core/BuildTools/Convert/Converter.cs
+++ b/src/Core/BuildTools/Convert/Converter.cs
@@ -7,10 +7,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Generator.Convert.Baking;
 using Newtonsoft.Json;
+using Silk.NET.BuildTools.Convert.Baking;
 
-namespace Generator.Convert
+namespace Silk.NET.BuildTools.Convert
 {
     /// <summary>
     /// The entry point for the bindings converter.

--- a/src/Core/BuildTools/Convert/Documentation/DocumentationReader.cs
+++ b/src/Core/BuildTools/Convert/Documentation/DocumentationReader.cs
@@ -8,11 +8,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using HtmlAgilityPack;
 using Humanizer;
 
-namespace Generator.Convert.Documentation
+namespace Silk.NET.BuildTools.Convert.Documentation
 {
     /// <summary>
     /// Contains methods for reading docs.gl XHTML files.

--- a/src/Core/BuildTools/Convert/Documentation/DocumentationWriter.cs
+++ b/src/Core/BuildTools/Convert/Documentation/DocumentationWriter.cs
@@ -7,13 +7,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
-using Generator.Common;
-using Generator.Convert.Construction;
 using Humanizer;
 using MoreLinq.Extensions;
+using Silk.NET.BuildTools.Common;
+using Silk.NET.BuildTools.Convert.Construction;
 
-namespace Generator.Convert.Documentation
+namespace Silk.NET.BuildTools.Convert.Documentation
 {
     /// <summary>
     /// Contains methods for writing documentation to profiles.

--- a/src/Core/BuildTools/Convert/Documentation/FunctionDocumentation.cs
+++ b/src/Core/BuildTools/Convert/Documentation/FunctionDocumentation.cs
@@ -5,10 +5,10 @@
 
 using System.Collections.Generic;
 using System.Text;
-using Generator.Common.Functions;
 using Humanizer;
+using Silk.NET.BuildTools.Common.Functions;
 
-namespace Generator.Convert.Documentation
+namespace Silk.NET.BuildTools.Convert.Documentation
 {
     /// <summary>
     /// Represents documentation for a function.

--- a/src/Core/BuildTools/Convert/Documentation/ParameterDocumentation.cs
+++ b/src/Core/BuildTools/Convert/Documentation/ParameterDocumentation.cs
@@ -3,7 +3,7 @@
 // You may modify and distribute Silk.NET under the terms
 // of the MIT license. See the LICENSE file for details.
 
-namespace Generator.Convert.Documentation
+namespace Silk.NET.BuildTools.Convert.Documentation
 {
     /// <summary>
     /// Represents documentation for a function's parameter.

--- a/src/Core/BuildTools/Convert/Documentation/ProfileDocumentation.cs
+++ b/src/Core/BuildTools/Convert/Documentation/ProfileDocumentation.cs
@@ -5,7 +5,7 @@
 
 using System.Collections.Generic;
 
-namespace Generator.Convert.Documentation
+namespace Silk.NET.BuildTools.Convert.Documentation
 {
     /// <summary>
     /// Represents parsed documentation for all functions in a profile.

--- a/src/Core/BuildTools/Convert/ProfileConstructor.cs
+++ b/src/Core/BuildTools/Convert/ProfileConstructor.cs
@@ -7,14 +7,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Xml.Linq;
-using Generator.Common;
-using Generator.Convert.Construction;
-using Generator.Convert.XML;
 using Newtonsoft.Json;
+using Silk.NET.BuildTools.Common;
+using Silk.NET.BuildTools.Convert.Construction;
+using Silk.NET.BuildTools.Convert.XML;
 
-namespace Generator.Convert
+namespace Silk.NET.BuildTools.Convert
 {
     /// <summary>
     /// A class for reading and creating profiles from XML.

--- a/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
+++ b/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
@@ -47,7 +47,7 @@ namespace Silk.NET.BuildTools.Convert.XML
         /// <returns>A friendlier representation of the XML file.</returns>
         public IEnumerable<XElement> Parse(string path)
         {
-            string[] contents = null;
+            string[] contents;
             if (path.StartsWith("http://") || path.StartsWith("https://"))
             {
                 // Download from the specified url into a temporary file
@@ -120,7 +120,7 @@ namespace Silk.NET.BuildTools.Convert.XML
             var elements = new SortedDictionary<string, XElement>();
             foreach (var e in ParseEnums(input).Concat(ParseFunctions(input)))
             {
-                var name = e.Attribute("name").Value;
+                var name = e.Attribute("name")?.Value;
                 var version = (e.Attribute("version") ?? new XAttribute("version", string.Empty)).Value;
                 var key = name + version;
                 if (!elements.ContainsKey(key))
@@ -142,14 +142,14 @@ namespace Silk.NET.BuildTools.Convert.XML
         /// <param name="feature">The XML element.</param>
         /// <returns>All API names in this XML element.</returns>
         /// <exception cref="NotSupportedException">The feature type is unknown.</exception>
-        private static string[] GetApiNames(XElement feature)
+        private static IEnumerable<string> GetApiNames(XElement feature)
         {
-            string[] apinames = null;
+            string[] apinames;
             switch (feature.Name.LocalName)
             {
                 case "feature":
                 {
-                    var v = feature.Attribute("api") != null ? feature.Attribute("api").Value : "gl|glcore";
+                    var v = feature.Attribute("api") != null ? feature.Attribute("api")?.Value : "gl|glcore";
                     if (v == "gl")
                     {
                         // Add all gl features to both compatibility (gl) and core (glcore) profiles.
@@ -158,14 +158,14 @@ namespace Silk.NET.BuildTools.Convert.XML
                         v = "gl|glcore";
                     }
 
-                    apinames = v.Split('|');
+                    apinames = v?.Split('|');
                     break;
                 }
 
                 case "extension":
                 {
-                    var v = feature.Attribute("supported") != null ? feature.Attribute("supported").Value : "gl|glcore";
-                    apinames = v.Split('|');
+                    var v = feature.Attribute("supported") != null ? feature.Attribute("supported")?.Value : "gl|glcore";
+                    apinames = v?.Split('|');
                     break;
                 }
 
@@ -186,10 +186,9 @@ namespace Silk.NET.BuildTools.Convert.XML
 
         private IEnumerable<XElement> ParseEnums(XDocument input)
         {
-            var features = input.Root.Elements("feature");
-            var extensions = input.Root.Elements("extensions").Elements("extension");
-            var enumerations = input.Root.Elements("enums").Elements("enum");
-            var groups = input.Root.Elements("groups").Elements("group");
+            var features = input.Root?.Elements("feature");
+            var extensions = input.Root?.Elements("extensions").Elements("extension");
+            var enumerations = input.Root?.Elements("enums").Elements("enum");
             var apis = new SortedDictionary<string, XElement>();
 
             // Build a list of all available tokens.
@@ -197,19 +196,22 @@ namespace Silk.NET.BuildTools.Convert.XML
             // so we need to keep separate lists for each API. Tokens
             // that are common go to the "default" list.
             var enums = new Dictionary<string, SortedDictionary<string, string>>();
-            foreach (var e in enumerations)
-            {
+            
+            if (enumerations == null) {
+                throw new NullReferenceException();
+            }
+            
+            foreach (var e in enumerations) {
                 var api = (e.Attribute("api") ?? new XAttribute("api", "default")).Value;
-                if (!enums.ContainsKey(api))
-                {
+                if (!enums.ContainsKey(api)) {
                     enums.Add(api, new SortedDictionary<string, string>());
                 }
 
                 enums[api]
                     .Add
                     (
-                        TrimName(e.Attribute("name").Value),
-                        e.Attribute("value").Value
+                        TrimName(e.Attribute("name")?.Value),
+                        e.Attribute("value")?.Value
                     );
             }
 
@@ -228,11 +230,10 @@ namespace Silk.NET.BuildTools.Convert.XML
             // see also: https://discordapp.com/channels/521092042781229087/587346162802229298/590211773399826438
             // see also: https://github.com/Ultz/Silk.NET/commit/f5f112bbd42d2f547cdab6ddd767609dfcfa99d9
             foreach (var feature in
-                features.Concat(extensions)
-//                  .Concat(groups)
-                    .OrderBy(f => TrimName(f.Attribute("name").Value)))
+                (features ?? throw new NullReferenceException()).Concat(extensions)
+                    .OrderBy(f => TrimName(f.Attribute("name")?.Value)))
             {
-                var version = feature.Attribute("number") != null ? feature.Attribute("number").Value : null;
+                var version = feature.Attribute("number") != null ? feature.Attribute("number")?.Value : null;
                 var apinames = GetApiNames(feature);
 
                 // An enum may belong to one or more APIs.
@@ -256,7 +257,7 @@ namespace Silk.NET.BuildTools.Convert.XML
 
                     var api = apis[key];
 
-                    var enum_name = TrimName(feature.Attribute("name").Value);
+                    var enum_name = TrimName(feature.Attribute("name")?.Value);
 
                     var e = new XElement
                     (
@@ -273,7 +274,7 @@ namespace Silk.NET.BuildTools.Convert.XML
                         feature.Elements("enum")
                             .Concat(feature.Elements("require").Elements("enum")))
                     {
-                        var token_name = TrimName(token.Attribute("name").Value);
+                        var token_name = TrimName(token.Attribute("name")?.Value);
                         var token_value =
                             enums.ContainsKey(apiname) && enums[apiname].ContainsKey(token_name)
                                 ? enums[apiname][token_name]
@@ -303,32 +304,33 @@ namespace Silk.NET.BuildTools.Convert.XML
 
                 foreach (var api in apis.Values)
                 {
-                    var apiname = api.Attribute("name").Value;
+                    var apiname = api.Attribute("name")?.Value;
 
                     // Mark deprecated enums
                     foreach (var token in feature.Elements("remove").Elements("enum"))
                     {
-                        var token_name = TrimName(token.Attribute("name").Value);
+                        var token_name = TrimName(token.Attribute("name")?.Value);
                         var deprecated =
                             api.Elements("enum")
                                 .Elements("token")
-                                .FirstOrDefault(t => t.Attribute("name").Value == token_name);
+                                .FirstOrDefault(t => t.Attribute("name")?.Value == token_name);
 
-                        if (deprecated != null)
+                        if (deprecated == null) {
+                            continue;
+                        }
+
+                        if (apiname == "glcore")
                         {
-                            if (apiname == "glcore")
-                            {
-                                // These tokens do not exist in the glcore profile, remove them
-                                api.Elements("enum")
-                                    .Elements("token")
-                                    .First(t => t.Attribute("name").Value == token_name)
-                                    .Remove();
-                            }
-                            else
-                            {
-                                // These tokens exist in all other profiles, mark them as deprecated.
-                                deprecated.Add(new XAttribute("deprecated", version));
-                            }
+                            // These tokens do not exist in the glcore profile, remove them
+                            api.Elements("enum")
+                                .Elements("token")
+                                .First(t => t.Attribute("name")?.Value == token_name)
+                                .Remove();
+                        }
+                        else
+                        {
+                            // These tokens exist in all other profiles, mark them as deprecated.
+                            deprecated.Add(new XAttribute("deprecated", version ?? throw new NullReferenceException()));
                         }
                     }
                 }
@@ -350,6 +352,10 @@ namespace Silk.NET.BuildTools.Convert.XML
             // It also includes information about the return type and parameters. These
             // are then parsed by the binding generator in order to create the necessary
             // overloads for correct use.
+            if (input.Root == null) {
+                throw new NullReferenceException();
+            }
+            
             var features = input.Root.Elements("feature");
             var extensions = input.Root.Elements("extensions").Elements("extension");
             var apis = new SortedDictionary<string, XElement>();
@@ -368,12 +374,16 @@ namespace Silk.NET.BuildTools.Convert.XML
             // information about versioning, extension support and deprecation.
             foreach (var feature in features.Concat(extensions))
             {
-                var category = TrimName(feature.Attribute("name").Value);
+                var category = TrimName(feature.Attribute("name")?.Value);
                 var apinames = GetApiNames(feature);
 
                 var version =
-                    (feature.Attribute("number") != null ? feature.Attribute("number").Value : string.Empty)?
+                    (feature.Attribute("number") != null ? feature.Attribute("number")?.Value : string.Empty)?
                     .Split('|');
+
+                if (version == null) {
+                    throw new NullReferenceException();
+                }
 
                 var i = -1;
                 foreach (var apiname in apinames)
@@ -402,10 +412,9 @@ namespace Silk.NET.BuildTools.Convert.XML
 
                     foreach (var command in feature.Elements("require").Elements("command"))
                     {
-                        var cmd_name = TrimName(command.Attribute("name").Value);
-                        var cmd_extension =
-                            ExtensionRegex.Match(cmd_name).Value ??
-                            (feature.Name == "extension" ? category.Substring(0, category.IndexOf("_")) : "Core");
+                        var cmd_name = TrimName(command.Attribute("name")?.Value);
+                        var cmd_extension = ExtensionRegex.Match(cmd_name).Value;
+                        
                         if (string.IsNullOrEmpty(cmd_extension))
                         {
                             cmd_extension = "Core";
@@ -427,31 +436,32 @@ namespace Silk.NET.BuildTools.Convert.XML
                 foreach (var api in apis.Values)
                 {
                     i++;
-                    var apiname = api.Attribute("name").Value;
+                    var apiname = api.Attribute("name")?.Value;
                     var cmd_version = version.Length > i ? version[i] : version[0];
 
                     // Mark all deprecated functions as such
                     foreach (var command in feature.Elements("remove").Elements("command"))
                     {
-                        var deprecated_name = TrimName(command.Attribute("name").Value);
+                        var deprecated_name = TrimName(command.Attribute("name")?.Value);
                         var deprecated =
                             api.Elements("function")
-                                .FirstOrDefault(t => t.Attribute("name").Value == deprecated_name);
+                                .FirstOrDefault(t => t.Attribute("name")?.Value == deprecated_name);
 
-                        if (deprecated != null)
+                        if (deprecated == null) {
+                            continue;
+                        }
+                        
+                        if (apiname == "glcore")
                         {
-                            if (apiname == "glcore")
-                            {
-                                // These tokens do not exist in the glcore profile, remove them
-                                api.Elements("function")
-                                    .First(t => t.Attribute("name").Value == deprecated_name)
-                                    .Remove();
-                            }
-                            else
-                            {
-                                // These tokens exist in all other profiles, mark them as deprecated.
-                                deprecated.Add(new XAttribute("deprecated", cmd_version));
-                            }
+                            // These tokens do not exist in the glcore profile, remove them
+                            api.Elements("function")
+                                .First(t => t.Attribute("name")?.Value == deprecated_name)
+                                .Remove();
+                        }
+                        else
+                        {
+                            // These tokens exist in all other profiles, mark them as deprecated.
+                            deprecated.Add(new XAttribute("deprecated", cmd_version));
                         }
                     }
                 }
@@ -466,17 +476,17 @@ namespace Silk.NET.BuildTools.Convert.XML
         /// <param name="api">The API.</param>
         /// <param name="function">The function to add to the API.</param>
         /// <exception cref="InvalidOperationException">The function has multiple extensions.</exception>
-        private void Merge(XElement api, XElement function)
+        private static void Merge(XElement api, XElement function)
         {
             var type = function.Name.LocalName;
-            var name = function.Attribute("name").Value;
-            var f = api.Elements(type).FirstOrDefault(p => p.Attribute("name").Value == name);
+            var name = function.Attribute("name")?.Value;
+            var f = api.Elements(type).FirstOrDefault(p => p.Attribute("name")?.Value == name);
             if (f != null)
             {
                 f.SetAttributeValue
                 (
                     "category",
-                    string.Join("|", f.Attribute("category").Value, function.Attribute("category").Value)
+                    string.Join("|", f.Attribute("category")?.Value, function.Attribute("category")?.Value)
                 );
                 f.SetAttributeValue
                 (
@@ -485,7 +495,7 @@ namespace Silk.NET.BuildTools.Convert.XML
                 );
 
                 // Sanity check: one function cannot belong to two different extensions
-                if (f.Attribute("extension").Value != function.Attribute("extension").Value)
+                if (f.Attribute("extension")?.Value != function.Attribute("extension")?.Value)
                 {
                     throw new InvalidOperationException("Different extensions for the same function");
                 }
@@ -527,7 +537,7 @@ namespace Silk.NET.BuildTools.Convert.XML
                 var param = FunctionParameterType(parameter);
 
                 var p = new XElement("param");
-                var pname = new XAttribute("name", parameter.Element("name").Value);
+                var pname = new XAttribute("name", parameter.Element("name")?.Value ?? throw new NullReferenceException());
                 var type = new XAttribute
                 (
                     "type",
@@ -538,7 +548,7 @@ namespace Silk.NET.BuildTools.Convert.XML
                 );
 
                 var count = parameter.Attribute("len") != null
-                    ? new XAttribute("count", parameter.Attribute("len").Value)
+                    ? new XAttribute("count", parameter.Attribute("len")?.Value ?? throw new NullReferenceException())
                     : null;
 
                 var flow = new XAttribute
@@ -568,7 +578,7 @@ namespace Silk.NET.BuildTools.Convert.XML
         /// <returns>The trimmed name.</returns>
         private string FunctionName(XElement e)
         {
-            return TrimName(e.Element("proto").Element("name").Value);
+            return TrimName(e.Element("proto")?.Element("name")?.Value);
         }
 
         /// <summary>
@@ -576,7 +586,7 @@ namespace Silk.NET.BuildTools.Convert.XML
         /// </summary>
         /// <param name="e">The proto element.</param>
         /// <returns>The type signature represented by the proto element.</returns>
-        private string FunctionParameterType(XElement e)
+        private static string FunctionParameterType(XElement e)
         {
             // Parse the C-like <proto> element. Possible instances:
             // Return types:
@@ -591,9 +601,9 @@ namespace Silk.NET.BuildTools.Convert.XML
             // - <param len="1"><ptype>GLsizei</ptype> *<name>length</name></param>
             //   -> <param name="length" type="GLsizei" count="1" />
             var proto = e.Value;
-            var name = e.Element("name").Value;
+            var name = e.Element("name")?.Value;
 
-            var ret = proto.Remove(proto.LastIndexOf(name)).Trim();
+            var ret = proto.Remove(proto.LastIndexOf(name, StringComparison.Ordinal)).Trim();
 
             return ret;
         }
@@ -607,12 +617,7 @@ namespace Silk.NET.BuildTools.Convert.XML
         /// <returns>The attribute.</returns>
         private static XAttribute Lookup(IDictionary<string, XElement> categories, string cmdName, string attribute)
         {
-            if (categories.ContainsKey(cmdName))
-            {
-                return categories[cmdName].Attribute(attribute);
-            }
-
-            return null;
+            return categories.ContainsKey(cmdName) ? categories[cmdName].Attribute(attribute) : null;
         }
     }
 }

--- a/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
+++ b/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
@@ -12,7 +12,7 @@ using System.Net;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
-namespace Generator.Convert.XML
+namespace Silk.NET.BuildTools.Convert.XML
 {
     /// <summary>
     /// A class which parses Khronos XML files and converts them to a friendlier format.

--- a/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
+++ b/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
@@ -309,7 +309,7 @@ namespace Silk.NET.BuildTools.Convert.XML
                     // Mark deprecated enums
                     foreach (var token in feature.Elements("remove").Elements("enum"))
                     {
-                        var token_name = TrimName(token.Attribute("name")?.Value);
+                        var token_name = TrimName(token.Attribute("name").Value);
                         var deprecated =
                             api.Elements("enum")
                                 .Elements("token")

--- a/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
+++ b/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
@@ -439,7 +439,7 @@ namespace Silk.NET.BuildTools.Convert.XML
                 foreach (var api in apis.Values)
                 {
                     i++;
-                    var apiname = api.Attribute("name")?.Value;
+                    var apiname = api.Attribute("name").Value;
                     var cmd_version = version.Length > i ? version[i] : version[0];
 
                     // Mark all deprecated functions as such

--- a/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
+++ b/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
@@ -115,7 +115,7 @@ namespace Silk.NET.BuildTools.Convert.XML
             var elements = new SortedDictionary<string, XElement>();
             foreach (var e in ParseEnums(input).Concat(ParseFunctions(input)))
             {
-                var name = e.Attribute("name")?.Value;
+                var name = e.Attribute("name").Value;
                 var version = (e.Attribute("version") ?? new XAttribute("version", string.Empty)).Value;
                 var key = name + version;
                 if (!elements.ContainsKey(key))

--- a/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
+++ b/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
@@ -415,7 +415,7 @@ namespace Silk.NET.BuildTools.Convert.XML
 
                     foreach (var command in feature.Elements("require").Elements("command"))
                     {
-                        var cmd_name = TrimName(command.Attribute("name")?.Value);
+                        var cmd_name = TrimName(command.Attribute("name").Value);
                         var cmd_extension = ExtensionRegex.Match(cmd_name).Value;
                         
                         if (string.IsNullOrEmpty(cmd_extension))

--- a/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
+++ b/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
@@ -258,7 +258,7 @@ namespace Silk.NET.BuildTools.Convert.XML
 
                     var api = apis[key];
 
-                    var enum_name = TrimName(feature.Attribute("name")?.Value);
+                    var enum_name = TrimName(feature.Attribute("name").Value);
 
                     var e = new XElement
                     (

--- a/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
+++ b/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
@@ -274,7 +274,7 @@ namespace Silk.NET.BuildTools.Convert.XML
                     
                     foreach (var token in feature.Elements("enum").Concat(feature.Elements("require").Elements("enum")))
                     {
-                        var token_name = TrimName(token.Attribute("name")?.Value);
+                        var token_name = TrimName(token.Attribute("name").Value);
                         var token_value =
                             enums.ContainsKey(apiname) && enums[apiname].ContainsKey(token_name)
                                 ? enums[apiname][token_name]

--- a/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
+++ b/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
@@ -100,12 +100,7 @@ namespace Silk.NET.BuildTools.Convert.XML
                 return name.Remove(0, EnumPrefix.Length);
             }
 
-            if (name.StartsWith(FuncPrefix))
-            {
-                return name.Remove(0, FuncPrefix.Length);
-            }
-
-            return name;
+            return name.StartsWith(FuncPrefix) ? name.Remove(0, FuncPrefix.Length) : name;
         }
 
         /// <summary>

--- a/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
+++ b/src/Core/BuildTools/Convert/XML/GLXmlParser.cs
@@ -181,9 +181,14 @@ namespace Silk.NET.BuildTools.Convert.XML
 
         private IEnumerable<XElement> ParseEnums(XDocument input)
         {
-            var features = input.Root?.Elements("feature");
-            var extensions = input.Root?.Elements("extensions").Elements("extension");
-            var enumerations = input.Root?.Elements("enums").Elements("enum");
+            if (input.Root == null)
+            {
+                throw new NullReferenceException();
+            }
+            
+            var features = input.Root.Elements("feature");
+            var extensions = input.Root.Elements("extensions").Elements("extension");
+            var enumerations = input.Root.Elements("enums").Elements("enum");
             var apis = new SortedDictionary<string, XElement>();
 
             // Build a list of all available tokens.
@@ -192,13 +197,16 @@ namespace Silk.NET.BuildTools.Convert.XML
             // that are common go to the "default" list.
             var enums = new Dictionary<string, SortedDictionary<string, string>>();
             
-            if (enumerations == null) {
+            if (enumerations == null)
+            {
                 throw new NullReferenceException();
             }
             
-            foreach (var e in enumerations) {
+            foreach (var e in enumerations)
+            {
                 var api = (e.Attribute("api") ?? new XAttribute("api", "default")).Value;
-                if (!enums.ContainsKey(api)) {
+                if (!enums.ContainsKey(api))
+                {
                     enums.Add(api, new SortedDictionary<string, string>());
                 }
 
@@ -224,9 +232,7 @@ namespace Silk.NET.BuildTools.Convert.XML
             // see also: https://github.com/KhronosGroup/OpenGL-Registry/pull/273
             // see also: https://discordapp.com/channels/521092042781229087/587346162802229298/590211773399826438
             // see also: https://github.com/Ultz/Silk.NET/commit/f5f112bbd42d2f547cdab6ddd767609dfcfa99d9
-            foreach (var feature in
-                (features ?? throw new NullReferenceException()).Concat(extensions)
-                    .OrderBy(f => TrimName(f.Attribute("name")?.Value)))
+            foreach (var feature in features.Concat(extensions).OrderBy(f => TrimName(f.Attribute("name")?.Value)))
             {
                 var version = feature.Attribute("number") != null ? feature.Attribute("number")?.Value : null;
                 var apinames = GetApiNames(feature);
@@ -265,9 +271,8 @@ namespace Silk.NET.BuildTools.Convert.XML
                                 : enum_name
                         )
                     );
-                    foreach (var token in
-                        feature.Elements("enum")
-                            .Concat(feature.Elements("require").Elements("enum")))
+                    
+                    foreach (var token in feature.Elements("enum").Concat(feature.Elements("require").Elements("enum")))
                     {
                         var token_name = TrimName(token.Attribute("name")?.Value);
                         var token_value =
@@ -310,7 +315,8 @@ namespace Silk.NET.BuildTools.Convert.XML
                                 .Elements("token")
                                 .FirstOrDefault(t => t.Attribute("name")?.Value == token_name);
 
-                        if (deprecated == null) {
+                        if (deprecated == null)
+                        {
                             continue;
                         }
 
@@ -347,7 +353,8 @@ namespace Silk.NET.BuildTools.Convert.XML
             // It also includes information about the return type and parameters. These
             // are then parsed by the binding generator in order to create the necessary
             // overloads for correct use.
-            if (input.Root == null) {
+            if (input.Root == null)
+            {
                 throw new NullReferenceException();
             }
             
@@ -376,7 +383,8 @@ namespace Silk.NET.BuildTools.Convert.XML
                     (feature.Attribute("number") != null ? feature.Attribute("number")?.Value : string.Empty)?
                     .Split('|');
 
-                if (version == null) {
+                if (version == null)
+                {
                     throw new NullReferenceException();
                 }
 

--- a/src/Core/BuildTools/Convert/XML/XContainerExtensions.cs
+++ b/src/Core/BuildTools/Convert/XML/XContainerExtensions.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 using System.Xml.Linq;
 using JetBrains.Annotations;
 
-namespace Generator.Convert.XML
+namespace Silk.NET.BuildTools.Convert.XML
 {
     /// <summary>
     /// Extension methods for the <see cref="XContainer" /> class.

--- a/src/Core/BuildTools/Convert/XML/XElementExtensions.cs
+++ b/src/Core/BuildTools/Convert/XML/XElementExtensions.cs
@@ -8,7 +8,7 @@ using System.Linq;
 using System.Xml.Linq;
 using JetBrains.Annotations;
 
-namespace Generator.Convert.XML
+namespace Silk.NET.BuildTools.Convert.XML
 {
     /// <summary>
     /// Extensions for the <see cref="XElement" /> class.

--- a/src/Core/BuildTools/Program.cs
+++ b/src/Core/BuildTools/Program.cs
@@ -10,9 +10,9 @@ using System.IO;
 using System.Linq;
 using CommandLine;
 using CommandLine.Text;
-using Generator.Bind;
-using Generator.Convert;
 using Newtonsoft.Json;
+using Silk.NET.BuildTools.Bind;
+using Silk.NET.BuildTools.Convert;
 using Silk.NET.BuildTools.Pipeline;
 
 namespace Silk.NET.BuildTools

--- a/src/OpenGL/Silk.NET.OpenGL.Legacy/GL.cs
+++ b/src/OpenGL/Silk.NET.OpenGL.Legacy/GL.cs
@@ -1,3 +1,4 @@
+using System;
 using Silk.NET.Core.Loader;
 using Silk.NET.Core.Native;
 
@@ -15,6 +16,10 @@ namespace Silk.NET.OpenGL.Legacy
         {
              ext = LibraryLoader<GL>.Load<T>(this);
              return ext != null;
+        }
+        public override bool IsExtensionPresent(string extension)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/OpenGL/Silk.NET.OpenGL/GL.cs
+++ b/src/OpenGL/Silk.NET.OpenGL/GL.cs
@@ -1,3 +1,4 @@
+using System;
 using Silk.NET.Core.Loader;
 using Silk.NET.Core.Native;
 
@@ -15,6 +16,10 @@ namespace Silk.NET.OpenGL
         {
              ext = LibraryLoader<GL>.Load<T>(this);
              return ext != null;
+        }
+        public override bool IsExtensionPresent(string extension)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/OpenGL/Silk.NET.OpenGLES/GL.cs
+++ b/src/OpenGL/Silk.NET.OpenGLES/GL.cs
@@ -1,3 +1,4 @@
+using System;
 using Silk.NET.Core.Loader;
 using Silk.NET.Core.Native;
 
@@ -15,6 +16,10 @@ namespace Silk.NET.OpenGLES
         {
              ext = LibraryLoader<GL>.Load<T>(this);
              return ext != null;
+        }
+        public override bool IsExtensionPresent(string extension)
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
# Summary of the PR
Fix some issues with the binder that prevent it from working properly.

- Add IsExtensionPresent to `GL`
- Make BuildTools output public interfaces instead of internal, so ADL can see them without needing assembly attributes
- Fix path in `generator.bat`
- Refactor namespaces in BuildTools
- Add new scripts for Linux
- Make scripts run BuildTools in release mode

# Related issues, Discord discussions, or proposals
None.

# Further Comments
None.