### PR TITLE
Add a window hosts API for monitor management and subwindows.

### DIFF
--- a/documentation/proposals/Proposal - Window Hosts (Monitors).md
+++ b/documentation/proposals/Proposal - Window Hosts (Monitors).md
@@ -8,8 +8,8 @@ More importantly, this proposal introduces monitor APIs (an example of a window 
 
 # Current Status
 - [x] Proposed
-- [ ] Discussed with API Review Board (ARB)
-- [ ] Approved
+- [x] Discussed with API Review Board (ARB)
+- [x] Approved
 - [ ] Implemented
 
 # Design Decisions

--- a/documentation/proposals/Proposal - Window Hosts (Monitors).md
+++ b/documentation/proposals/Proposal - Window Hosts (Monitors).md
@@ -1,0 +1,71 @@
+# Summary
+This proposal introduces the concept of a "window host" to Silk.NET - an object on which windows can be created.
+More importantly, this proposal introduces monitor APIs (an example of a window host) and subwindows
+- where all windows are also window hosts.
+
+# Contributors
+- Dylan P, Ultz Limited
+
+# Current Status
+- [x] Proposed
+- [ ] Discussed with API Review Board (ARB)
+- [ ] Approved
+- [ ] Implemented
+
+# Design Decisions
+This proposal purposely excludes window views as described in the views proposal, as barely any of the concepts
+are applicable to mobile/view-based windowing platforms.
+
+# Proposed API
+
+## Window hosts
+
+### IWindowHost
+```cs
+public interface IWindowHost
+{
+    IWindow CreateWindow(WindowOptions opts);
+}
+```
+
+### IWindowPlatform
+```diff
+-public interface IWindowPlatform
++public interface IWindowPlatform : IWindowHost
+{
+-    IWindow GetWindow(WindowOptions opts);
++    IWindow CreateWindow(WindowOptions opts);
++    IEnumerable<IMonitor> GetMonitors();
+}
+```
+
+### IWindow
+```diff
+-public interface IWindow : IView, IWindowProperties, IWindowFunctions, IWindowEvents
++public interface IWindow : IView, IWindowHost, IWindowProperties, IWindowFunctions, IWindowEvents
+{
+     // NOTE: Purposely not included in IWindowProperties as the hosts API should be used to create a window on a monitor, not the WindowOptions API.
++    IMonitor Monitor { get; set; }
+}
+```
+
+## Monitors
+### IMonitor
+```cs
+public interface IMonitor : IWindowHost
+{
+    string Name { get; }
+    int Index { get; }
+    Rectangle Bounds { get; }
+    int RefreshRate { get; }
+}
+```
+
+### Monitor
+```cs
+public static class Monitor
+{
+    public static IEnumerable<IMonitor> GetMonitors();
+    public static IMonitor GetMainMonitor();
+}
+```


### PR DESCRIPTION
# Summary of the PR
This PR introduces the concept of a "window host" to Silk.NET - an object on which windows can be created. More importantly, this proposal introduces monitor APIs (an example of a window host) and subwindows - where all windows are also window hosts.

# Related issues, Discord discussions, or proposals
Could be linked to #82 

# Further Comments
- Discussion Point: do we want to call them Screens or Monitors?