### PR TITLE
F# Tutorial 1.3 - Shaders

### DIFF
--- a/examples/F#/OpenGL/Tutorial 1.3 - Shaders/Program.fs
+++ b/examples/F#/OpenGL/Tutorial 1.3 - Shaders/Program.fs
@@ -1,9 +1,104 @@
-﻿open System
+#nowarn "9"
+
+open Microsoft.FSharp.NativeInterop
+
+open System
+open System.Drawing
+
+open Silk.NET.Windowing
+open Silk.NET.Windowing.Common
+open Silk.NET.OpenGL
+open Silk.NET.Input
+open Silk.NET.Input.Common
+
+let aPosLocation = 0u
+let aColorLocation = 1u
+
 
 [<EntryPoint>]
-let main argv =
-    printfn "This tutorial has not been written yet."
-    printfn "Have a go at using the C++ version of this tutorial at:"
-    printfn "    learnopengl.com"
-    printfn "Have fun!"
+let main _ =
+    // Setup some options and create a Window
+    let mutable options = WindowOptions.Default
+    options.Size <- Size(800, 600)
+    options.Title <- "LearnOpenGL with Silk.NET"
+    let mutable window = Window.Create(options)
+    let mutable gl = null
+    let mutable vao = 0u
+    let mutable shaderProgram = 0u
+
+    // Our Key Down handler
+    let onKeyDown = Action<IKeyboard, Key, int>(fun _ key _ ->
+        match key with
+        | Key.Escape -> window.Close()
+        | _ -> ()
+    )
+
+    // Here we initialize OpenGL with our scene
+    window.add_Load (fun () -> 
+        // Wait for Window to load before we can get a handle to OpenGL
+        gl <- GL.GetApi()
+
+        // Add a key down handler on any keyboard we find
+        let input = window.GetInput()
+        input.Keyboards
+        |> Seq.iter (fun keyboard -> keyboard.add_KeyDown onKeyDown)
+
+        // Create our shader program
+        shaderProgram <- Shader.create gl
+
+        // Vertices in Counter-clockwise order
+        let vertices = [|
+            // positions         colors
+            -0.5f; -0.5f; 0.0f;  1.0f; 0.0f; 0.0f // bottom left  
+            0.5f; -0.5f; 0.0f;   0.0f; 1.0f; 0.0f // bottom right 
+            0.0f;  0.5f; 0.0f;   0.0f; 0.0f; 1.0f // top    
+        |]
+
+        // VAO stores our vertex state
+        vao <- gl.GenVertexArray()
+        let vbo = gl.GenBuffer()
+
+        gl.BindVertexArray(vao)
+        gl.BindBuffer(GLEnum.ArrayBuffer, vbo)
+
+        // gl.BufferData requires the data to be passed as a void pointer.
+        // We get a pointer to the vertex array and convert it.
+        use verticesPtr = fixed vertices
+        let voidPtr = verticesPtr |> NativePtr.toVoidPtr
+        let size = uint32 (vertices.Length * sizeof<float32>)
+        gl.BufferData(GLEnum.ArrayBuffer, size, voidPtr, GLEnum.StaticDraw)
+
+        // Position attribute
+        gl.VertexAttribPointer(aPosLocation, 3, GLEnum.Float, false, 6u * uint32 sizeof<float32>, 0)
+        gl.EnableVertexAttribArray(aPosLocation)
+
+        // Color attribute
+        gl.VertexAttribPointer(aColorLocation, 3, GLEnum.Float, false, 6u * uint32 sizeof<float32>, 3 * sizeof<float32>)
+        gl.EnableVertexAttribArray(aColorLocation)
+
+        // Unbind our vao and vbo
+        gl.BindBuffer(GLEnum.ArrayBuffer, 0u)
+        gl.BindVertexArray(0u)
+    )
+
+    window.add_Render (fun _ ->
+        // Set a background color and clear the screen with that color
+        gl.ClearColor(0.2f, 0.3f, 0.3f, 1.0f)
+        gl.Clear(uint32 GLEnum.ColorBufferBit)
+
+        // We want to use the shader program we setup on load
+        // along with the vao that holds info about the vertices and
+        // how they'll be used
+        gl.UseProgram(shaderProgram)
+        gl.BindVertexArray(vao)
+
+        // Finally, our draw call renders 3u vertices starting at index 0
+        gl.DrawArrays(GLEnum.Triangles, 0, 3u)
+    )
+
+    // We'll need to tell OpenGL to resize if the user resizes the window
+    window.add_Resize (fun (size: Size) -> gl.Viewport(size))
+
+    window.Run()
+
     0

--- a/examples/F#/OpenGL/Tutorial 1.3 - Shaders/Tutorial 1.3 - Shaders.fsproj
+++ b/examples/F#/OpenGL/Tutorial 1.3 - Shaders/Tutorial 1.3 - Shaders.fsproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -7,7 +7,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Compile Include="Program.fs"/>
+        <Compile Include="shader.fs" />
+        <Compile Include="Program.fs" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Silk.NET.Input" Version="1.0.0-preview3" />
+      <PackageReference Include="Silk.NET.OpenGL" Version="1.0.0-preview3" />
+      <PackageReference Include="Silk.NET.Windowing" Version="1.0.0-preview3" />
     </ItemGroup>
 
 </Project>

--- a/examples/F#/OpenGL/Tutorial 1.3 - Shaders/shader.frag
+++ b/examples/F#/OpenGL/Tutorial 1.3 - Shaders/shader.frag
@@ -1,0 +1,9 @@
+#version 330 core
+
+in vec3 color;
+
+out vec4 FragColor;
+
+void main() {
+    FragColor = vec4(color, 1.0f);
+}

--- a/examples/F#/OpenGL/Tutorial 1.3 - Shaders/shader.fs
+++ b/examples/F#/OpenGL/Tutorial 1.3 - Shaders/shader.fs
@@ -1,0 +1,48 @@
+module Shader
+
+open System
+open Silk.NET.OpenGL
+
+// Used to load and compile the vertex and fragment shaders
+let private createShader (gl: GL) (shaderType: GLEnum) path =
+    let shader = gl.CreateShader(shaderType)
+    let source = IO.File.ReadAllText(path)
+
+    // Load and compile the shader
+    gl.ShaderSource(shader, source)
+    gl.CompileShader(shader)
+
+    // Throw an exception if compiling the shader failed
+    // The info log will tell us what line the shader failed on
+    // so we can inspect the source.
+    if gl.GetShader(shader, GLEnum.CompileStatus) <> 1 then
+        let info = gl.GetShaderInfoLog(shader)
+        gl.DeleteShader(shader)
+        failwith (sprintf "Error creating shader: %A" info)
+
+    shader
+
+
+let create (gl: GL) =
+    // Load and compile our vertex and fragment shaders
+    let vertexShader = createShader gl GLEnum.VertexShader "shader.vert"
+    let fragmentShader = createShader gl GLEnum.FragmentShader "shader.frag"
+
+    // Link the vertex and fragment shaders into a shader program
+    let shaderProgram = gl.CreateProgram()
+    gl.AttachShader(shaderProgram, vertexShader)
+    gl.AttachShader(shaderProgram, fragmentShader)
+    gl.LinkProgram(shaderProgram)
+    
+    // We're done with the shaders so they can be removed to free memory
+    gl.DetachShader(shaderProgram, fragmentShader)
+    gl.DetachShader(shaderProgram, vertexShader)
+    gl.DeleteShader(vertexShader)
+    gl.DeleteShader(fragmentShader)
+
+    // Throw an exception if linking has failed
+    if gl.GetProgram(shaderProgram, GLEnum.LinkStatus) <> 1 then
+        let info = gl.GetProgramInfoLog(shaderProgram)
+        failwith (sprintf "Error linking program %A" info)
+
+    shaderProgram

--- a/examples/F#/OpenGL/Tutorial 1.3 - Shaders/shader.vert
+++ b/examples/F#/OpenGL/Tutorial 1.3 - Shaders/shader.vert
@@ -1,0 +1,11 @@
+#version 330 core
+
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec3 aColor;
+
+out vec3 color;
+
+void main() {
+    gl_Position = vec4(aPos, 1.0);
+    color = aColor;
+}


### PR DESCRIPTION
Followed 3.3 Shader Class code somewhat but although F# has support for classes to aid Interop, a more idiomatic approach is to use functions which is what I've done. It also doesn't yet have some of the other abstractions in there as they aren't used yet.

 `Shader.use` doesn't really make sense either yet as you need to pass in everything to make that call and `use` is a reserved word so be `Shader.useProgram gl programId` just to call `gl.UseProgram(programId)`. Hopefully a more obvious abstraction will present itself in later tutorials
