### PR TITLE
Replaced vsync sleep logic

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Desktop/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Desktop/GlfwWindow.cs
@@ -625,11 +625,12 @@ namespace Silk.NET.Windowing.Desktop
 
             // Calculate delta and run frame.
             var delta = _updateStopwatch.Elapsed.TotalSeconds;
-            Update?.Invoke(delta);
 
             // Reset
             _updateStopwatch.Restart();
             _updatedWithinPeriod = false;
+
+            Update?.Invoke(delta);            
         }
 
         /// <summary>
@@ -668,13 +669,6 @@ namespace Silk.NET.Windowing.Desktop
             }
 
             var delta = _renderStopwatch.Elapsed.TotalSeconds;
-            
-            Render?.Invoke(delta);
-
-            if (ShouldSwapAutomatically)
-            {
-                SwapBuffers();
-            }
 
             //Reset
             _renderStopwatch.Restart();
@@ -684,6 +678,13 @@ namespace Silk.NET.Windowing.Desktop
             if (VSync == VSyncMode.Adaptive)
             {
                 _glfw.SwapInterval(IsRunningSlowly ? 0 : 1);
+            }
+
+            Render?.Invoke(delta);
+
+            if (ShouldSwapAutomatically)
+            {
+                SwapBuffers();
             }
         }
 

--- a/src/Windowing/Silk.NET.Windowing.Desktop/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Desktop/GlfwWindow.cs
@@ -601,7 +601,7 @@ namespace Silk.NET.Windowing.Desktop
             // If using a capped framerate without vsync, we have to do some synchronization-related things.
             // before rendering.
             if (UpdatesPerSecond >= double.Epsilon
-                && (VSync == VSyncMode.Off || VSync == VSyncMode.Adaptive && IsRunningSlowly))
+                && (VSync == VSyncMode.Off || VSync == VSyncMode.Adaptive))
             {
                 // Calculate the amount of remaining time till next update.
                 var remainingTime = _updatePeriod - _updateStopwatch.Elapsed.TotalSeconds;
@@ -618,7 +618,7 @@ namespace Silk.NET.Windowing.Desktop
                     _updatedWithinPeriod = true; // Remember we weren't too late.
                     _isRunningSlowlyTries = 0;
 
-                    if (remainingTime > 0.0)
+                    if (remainingTime > 0.0 && VSync != VSyncMode.Adaptive)
                         return; // Not the time for update yet.
                 }
             }
@@ -640,7 +640,7 @@ namespace Silk.NET.Windowing.Desktop
         {
             // Identical to RaiseUpdateFrame.
             if (FramesPerSecond >= double.Epsilon
-                && (VSync == VSyncMode.Off || VSync == VSyncMode.Adaptive && IsRunningSlowly))
+                && (VSync == VSyncMode.Off || VSync == VSyncMode.Adaptive))
             {
                 // Calculate the amount of remaining time till next rendering..
                 var remainingTime = _renderPeriod - _renderStopwatch.Elapsed.TotalSeconds;
@@ -660,7 +660,7 @@ namespace Silk.NET.Windowing.Desktop
                         _renderedWithinPeriod = true; // Remember we weren't too late.
                         _isRunningSlowlyTries = 0;
 
-                        if (remainingTime > 0.0)
+                        if (remainingTime > 0.0 && VSync != VSyncMode.Adaptive)
                             return; // Not the time for update yet.
                     }
                 }


### PR DESCRIPTION
# Summary of the PR
Replaced VSYNC sleep logic with an approach where the events are just not called until the time is right. This avoids many problems with frame rates and update rates.

# Related issues, Discord discussions, or proposals
Closes #93 
#94 

# Further Comments
Testing seems to work as expected. Needs some testing for adaptive vsync.