### PR TITLE
Monitor video modes and gamma correction

### DIFF
--- a/src/Lab/MonitorPlayground/MonitorPlayground.csproj
+++ b/src/Lab/MonitorPlayground/MonitorPlayground.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netcoreapp3.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IMonitor.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IMonitor.cs
@@ -3,6 +3,7 @@
 // You may modify and distribute Silk.NET under the terms
 // of the MIT license. See the LICENSE file for details.
 
+using System.Collections.Generic;
 using System.Drawing;
 
 namespace Silk.NET.Windowing.Common
@@ -41,6 +42,6 @@ namespace Silk.NET.Windowing.Common
         /// Get all video modes that this monitor supports.
         /// </summary>
         /// <returns>An array of all video modes.</returns>
-        VideoMode[] GetAllVideoModes();
+        IEnumerable<VideoMode> GetAllVideoModes();
     }
 }

--- a/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IMonitor.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IMonitor.cs
@@ -7,11 +7,40 @@ using System.Drawing;
 
 namespace Silk.NET.Windowing.Common
 {
+    /// <summary>
+    /// An interface representing a monitor.
+    /// </summary>
     public interface IMonitor : IWindowHost
     {
+        /// <summary>
+        /// The name of this monitor.
+        /// </summary>
         string Name { get; }
+        
+        /// <summary>
+        /// The index of this monitor.
+        /// </summary>
         int Index { get; }
+        
+        /// <summary>
+        /// The bounds of this monitor.
+        /// </summary>
         Rectangle Bounds { get; }
+        
+        /// <summary>
+        /// The current video mode of this monitor.
+        /// </summary>
         VideoMode VideoMode { get; }
+        
+        /// <summary>
+        /// This monitor's gamma correction.
+        /// </summary>
+        float Gamma { get; set; }
+
+        /// <summary>
+        /// Get all video modes that this monitor supports.
+        /// </summary>
+        /// <returns>An array of all video modes.</returns>
+        VideoMode[] GetAllVideoModes();
     }
 }

--- a/src/Windowing/Silk.NET.Windowing.Desktop/GlfwMonitor.cs
+++ b/src/Windowing/Silk.NET.Windowing.Desktop/GlfwMonitor.cs
@@ -68,18 +68,18 @@ namespace Silk.NET.Windowing.Desktop
             }
         }
 
-        public VideoMode[] GetAllVideoModes()
+        public IEnumerable<VideoMode> GetAllVideoModes()
         {
             var rawVideoModes = GlfwProvider.GLFW.Value.GetVideoModes(Handle, out var count);
 
-            List<VideoMode> videoModes = new List<VideoMode>();
+            var videoModes = new List<VideoMode>();
 
             for (var i = 0; i < count; i++)
             {
                 videoModes.Add(new VideoMode(new Size(rawVideoModes[i].Width, rawVideoModes[i].Height), rawVideoModes[i].RefreshRate));
             }
 
-            return videoModes.ToArray();
+            return videoModes;
         }
     }
 }

--- a/src/Windowing/Silk.NET.Windowing.Desktop/GlfwMonitor.cs
+++ b/src/Windowing/Silk.NET.Windowing.Desktop/GlfwMonitor.cs
@@ -3,7 +3,6 @@
 // You may modify and distribute Silk.NET under the terms
 // of the MIT license. See the LICENSE file for details.
 
-using System;
 using System.Drawing;
 using Silk.NET.GLFW;
 using Silk.NET.Windowing.Common;
@@ -13,6 +12,8 @@ namespace Silk.NET.Windowing.Desktop
 {
     internal unsafe class GlfwMonitor : IMonitor
     {
+        private float _gamma = 1.0f;
+        
         public Monitor* Handle { get; }
 
         public GlfwMonitor(Monitor* monitor, int index)
@@ -53,6 +54,16 @@ namespace Silk.NET.Windowing.Desktop
                     new Size(videoMode->Width, videoMode->Height),
                     videoMode->RefreshRate
                 );
+            }
+        }
+
+        public float Gamma
+        {
+            get => _gamma;
+            set
+            {
+                _gamma = value;
+                GlfwProvider.GLFW.Value.SetGamma(Handle, value);
             }
         }
     }

--- a/src/Windowing/Silk.NET.Windowing.Desktop/GlfwMonitor.cs
+++ b/src/Windowing/Silk.NET.Windowing.Desktop/GlfwMonitor.cs
@@ -3,6 +3,7 @@
 // You may modify and distribute Silk.NET under the terms
 // of the MIT license. See the LICENSE file for details.
 
+using System.Collections.Generic;
 using System.Drawing;
 using Silk.NET.GLFW;
 using Silk.NET.Windowing.Common;
@@ -65,6 +66,20 @@ namespace Silk.NET.Windowing.Desktop
                 _gamma = value;
                 GlfwProvider.GLFW.Value.SetGamma(Handle, value);
             }
+        }
+
+        public VideoMode[] GetAllVideoModes()
+        {
+            var rawVideoModes = GlfwProvider.GLFW.Value.GetVideoModes(Handle, out var count);
+
+            List<VideoMode> videoModes = new List<VideoMode>();
+
+            for (var i = 0; i < count; i++)
+            {
+                videoModes.Add(new VideoMode(new Size(rawVideoModes[i].Width, rawVideoModes[i].Height), rawVideoModes[i].RefreshRate));
+            }
+
+            return videoModes.ToArray();
         }
     }
 }

--- a/src/Windowing/Silk.NET.Windowing.Desktop/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Desktop/GlfwWindow.cs
@@ -159,14 +159,12 @@ namespace Silk.NET.Windowing.Desktop
         public bool ShouldSwapAutomatically { get; }
 
         /// <inheritdoc />
-        public unsafe VideoMode VideoMode
+        public VideoMode VideoMode
         {
             get
             {
                 var monitor = Monitor;
-                return monitor != null
-                    ? monitor.VideoMode
-                    : _initialOptions.VideoMode;
+                return monitor?.VideoMode ?? _initialOptions.VideoMode;
             }
         }
 
@@ -193,7 +191,7 @@ namespace Silk.NET.Windowing.Desktop
             }
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc cref="Size" />
         public Size Size
         {
             get => _size;
@@ -315,8 +313,8 @@ namespace Silk.NET.Windowing.Desktop
                                 _glfw.SetWindowMonitor
                                 (
                                     _windowPtr, monitor, 0, 0,
-                                    resolution.HasValue ? resolution.Value.Width : mode->Width,
-                                    resolution.HasValue ? resolution.Value.Height : mode->Height,
+                                    resolution?.Width ?? mode->Width,
+                                    resolution?.Height ?? mode->Height,
                                     videoMode.RefreshRate ?? mode->RefreshRate
                                 );
                                 break;

--- a/src/Windowing/Silk.NET.Windowing.Desktop/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Desktop/GlfwWindow.cs
@@ -159,14 +159,7 @@ namespace Silk.NET.Windowing.Desktop
         public bool ShouldSwapAutomatically { get; }
 
         /// <inheritdoc />
-        public VideoMode VideoMode
-        {
-            get
-            {
-                var monitor = Monitor;
-                return monitor?.VideoMode ?? _initialOptions.VideoMode;
-            }
-        }
+        public VideoMode VideoMode => Monitor?.VideoMode ?? _initialOptions.VideoMode;
 
         /// <inheritdoc />
         public int? PreferredDepthBufferBits => _initialOptions.PreferredDepthBufferBits;


### PR DESCRIPTION
# Summary of the PR
Adds the ability to get all of a monitor's video mode and gamma correction.

# Related issues, Discord discussions, or proposals
Closes #110 

# Further Comments
GLFW primarily works with gamma ramps, not plain exponents. While it has a function to set gamma ramp via exponent, there doesn't seem to be a way to get that exponent *back* from GLFW. Because of this, we'll have to assume the default gamma is 1.0 when a monitor is first created. I don't know enough about monitors to know if that's going to be an issue or not.

Setting video modes will come in a later PR, GLFW implements this in a very odd way that makes it difficult to implement.