### PR TITLE
Wrapping Glfw's PostEmptyEvent method

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IView.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Interfaces/IView.cs
@@ -102,6 +102,12 @@ namespace Silk.NET.Windowing.Common
         void DoEvents();
 
         /// <summary>
+        /// When using <see cref="WindowOptions.IsEventDriven"/> = true, wakes the main thread from
+        /// its blocking wait on incoming events.  Can be called from any thread.
+        /// </summary>
+        void ContinueEvents();
+
+        /// <summary>
         /// Unloads the window on the underlying platform.
         /// </summary>
         void Reset();

--- a/src/Windowing/Silk.NET.Windowing.Desktop/GlfwWindow.cs
+++ b/src/Windowing/Silk.NET.Windowing.Desktop/GlfwWindow.cs
@@ -647,6 +647,12 @@ namespace Silk.NET.Windowing.Desktop
         }
 
         /// <inheritdoc />
+        public void ContinueEvents()
+        {
+            _glfw.PostEmptyEvent();
+        }
+
+        /// <inheritdoc />
         public unsafe void Reset()
         {
             _updateStopwatch.Stop();


### PR DESCRIPTION
# Summary of the PR
As a follow up to the recent changes allowing a window to be event-driven, this change allows another thread to post an empty message to the event queue to wake up the main thread.

# What version does this PR target?
Current

# Related issues, Discord discussions, or proposals
Discussed wtih @Perksey on Discord
