### PR TITLE
Readonly Vectors

### DIFF
--- a/src/Maths/Silk.NET.Maths/Vector2.cs
+++ b/src/Maths/Silk.NET.Maths/Vector2.cs
@@ -85,10 +85,7 @@ namespace Silk.NET.Maths
 
         public Vector2<T> PerpendicularLeft => new Vector2<T>(Scalar<T>.Negate(Y), X);
 
-        public Vector2<T> Normalized()
-        {
-            return Normalize(this);
-        }
+        public Vector2<T> Normalize() => Normalize(this);
 
         public static Vector2<T> Add(Vector2<T> a, Vector2<T> b)
         {

--- a/src/Maths/Silk.NET.Maths/Vector2.cs
+++ b/src/Maths/Silk.NET.Maths/Vector2.cs
@@ -27,7 +27,7 @@ namespace Silk.NET.Maths
     */
         
     [Serializable]
-    public struct Vector2<T> : IEquatable<Vector2<T>>, IFormattable where T : unmanaged, IFormattable
+    public readonly struct Vector2<T> : IEquatable<Vector2<T>>, IFormattable where T : unmanaged, IFormattable
     {
         public static Vector2<T> UnitX => new Vector2<T>(Scalar<T>.One, default);
 
@@ -42,8 +42,8 @@ namespace Silk.NET.Maths
         public static Vector2<T> NegativeInfinity => new Vector2<T>(Scalar<T>.NegativeInfinity);
 
         public static unsafe int SizeInBytes => sizeof(Vector2<T>);
-        public T X;
-        public T Y;
+        public readonly T X;
+        public readonly T Y;
 
         public Vector2(T value) : this(value, value)
         { }
@@ -54,9 +54,13 @@ namespace Silk.NET.Maths
             Y = y;
         }
 
+        public Vector2<T> WithX(T x) => new Vector2<T>(x, Y);
+        
+        public Vector2<T> WithY(T y) => new Vector2<T>(X, y);
+        
         public T this[int index]
         {
-            readonly get
+            get
             {
                 if (index == 0)
                 {
@@ -71,39 +75,19 @@ namespace Silk.NET.Maths
                 Scalar<T>.ThrowIndexOutOfRange();
                 return default;
             }
-            set
-            {
-                if (index == 0)
-                {
-                    X = value;
-                }
-                else if (index == 1)
-                {
-                    Y = value;
-                }
-                else
-                {
-                    Scalar<T>.ThrowIndexOutOfRange();
-                }
-            }
         }
 
-        public readonly T Length => Scalar<T>.SquareRoot(LengthSquared);
+        public T Length => Scalar<T>.SquareRoot(LengthSquared);
 
-        public readonly T LengthSquared => Dot(this, this);
+        public T LengthSquared => Dot(this, this);
 
-        public readonly Vector2<T> PerpendicularRight => new Vector2<T>(Y, Scalar<T>.Negate(X));
+        public Vector2<T> PerpendicularRight => new Vector2<T>(Y, Scalar<T>.Negate(X));
 
-        public readonly Vector2<T> PerpendicularLeft => new Vector2<T>(Scalar<T>.Negate(Y), X);
+        public Vector2<T> PerpendicularLeft => new Vector2<T>(Scalar<T>.Negate(Y), X);
 
-        public readonly Vector2<T> Normalized()
+        public Vector2<T> Normalized()
         {
             return Normalize(this);
-        }
-
-        public void Normalize()
-        {
-            this = Normalize(this);
         }
 
         public static Vector2<T> Add(Vector2<T> a, Vector2<T> b)
@@ -429,11 +413,11 @@ namespace Silk.NET.Maths
             return new Vector2<T>(values.X, values.Y);
         }
 
-        public override readonly string ToString() => ToString("G");
+        public override string ToString() => ToString("G");
 
-        public readonly string ToString(string format) => ToString(format, CultureInfo.CurrentCulture);
+        public string ToString(string format) => ToString(format, CultureInfo.CurrentCulture);
 
-        public readonly string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string format, IFormatProvider formatProvider)
         {
             var sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
@@ -446,7 +430,7 @@ namespace Silk.NET.Maths
             return sb.ToString();
         }
 
-        public override readonly int GetHashCode()
+        public override int GetHashCode()
         {
 #if NETSTANDARD2_1
             return HashCode.Combine(X, Y);
@@ -455,18 +439,18 @@ namespace Silk.NET.Maths
 #endif
         }
 
-        public override readonly bool Equals(object obj) => obj is Vector2<T> vec && Equals(vec);
+        public override bool Equals(object obj) => obj is Vector2<T> vec && Equals(vec);
 
-        public readonly bool Equals(Vector2<T> other) => Scalar<T>.Equal(X, other.X) && Scalar<T>.Equal(Y, other.Y);
+        public bool Equals(Vector2<T> other) => Scalar<T>.Equal(X, other.X) && Scalar<T>.Equal(Y, other.Y);
 
-        public readonly void Deconstruct(out T x, out T y)
+        public void Deconstruct(out T x, out T y)
         {
             x = X;
             y = Y;
         }
 
 #if INTRINSICS 
-        public readonly Vector64<T> AsVector64()
+        public Vector64<T> AsVector64()
         {
             if (typeof(T) == typeof(byte))
             {
@@ -512,7 +496,7 @@ namespace Silk.NET.Maths
             return default;
         }
 
-        public readonly Vector128<T> AsVector128()
+        public Vector128<T> AsVector128()
         {
             if (typeof(T) == typeof(byte))
             {
@@ -573,7 +557,7 @@ namespace Silk.NET.Maths
             return default;
         }
 
-        public readonly Vector256<T> AsVector256()
+        public Vector256<T> AsVector256()
         {
             if (typeof(T) == typeof(byte))
             {
@@ -636,7 +620,7 @@ namespace Silk.NET.Maths
 #endif
 
 #if BTEC_INTRINSICS
-        public readonly unsafe Vector<T> AsVector()
+        public unsafe Vector<T> AsVector()
         { 
             if (Vector<T>.Count >= 2)
             {

--- a/src/Maths/Silk.NET.Maths/Vector3.cs
+++ b/src/Maths/Silk.NET.Maths/Vector3.cs
@@ -84,7 +84,7 @@ namespace Silk.NET.Maths
 
         public T LengthSquared => Dot(this, this);
 
-        public Vector3<T> Normalized() => Normalize(this);
+        public Vector3<T> Normalize() => Normalize(this);
 
         public static Vector3<T> Add(Vector3<T> a, Vector3<T> b)
         {

--- a/src/Maths/Silk.NET.Maths/Vector3.cs
+++ b/src/Maths/Silk.NET.Maths/Vector3.cs
@@ -16,7 +16,7 @@ using System.Runtime.Intrinsics;
 namespace Silk.NET.Maths
 {
     [Serializable]
-    public struct Vector3<T> : IEquatable<Vector3<T>>, IFormattable where T : unmanaged, IFormattable
+    public readonly struct Vector3<T> : IEquatable<Vector3<T>>, IFormattable where T : unmanaged, IFormattable
     {
         public static Vector3<T> UnitX => new Vector3<T>(Scalar<T>.One, default, default);
         public static Vector3<T> UnitY => new Vector3<T>(default, Scalar<T>.One, default);
@@ -26,9 +26,9 @@ namespace Silk.NET.Maths
         public static Vector3<T> PositiveInfinity => new Vector3<T>(Scalar<T>.PositiveInfinity);
         public static Vector3<T> NegativeInfinity => new Vector3<T>(Scalar<T>.NegativeInfinity);
         public static unsafe int SizeInBytes => sizeof(Vector3<T>);
-        public T X;
-        public T Y;
-        public T Z;
+        public readonly T X;
+        public readonly T Y;
+        public readonly T Z;
 
         public Vector3(T value) : this(value, value, value)
         { }
@@ -39,6 +39,12 @@ namespace Silk.NET.Maths
             Y = y;
             Z = z;
         }
+
+        public Vector3<T> WithX(T x) => new Vector3<T>(x, Y, Z);
+        
+        public Vector3<T> WithY(T y) => new Vector3<T>(X, y, Z);
+        
+        public Vector3<T> WithZ(T z) => new Vector3<T>(X, Y, z);
 
         public Vector3(Vector2<T> v, T z = default)
         {
@@ -58,7 +64,7 @@ namespace Silk.NET.Maths
 
         public T this[int index]
         {
-            readonly get
+            get
             {
                 if (index == 0)
                     return X;
@@ -72,29 +78,13 @@ namespace Silk.NET.Maths
                 Scalar<T>.ThrowIndexOutOfRange();
                 return default;
             }
-            set
-            {
-                if (index == 0)
-                    X = value;
-                else if (index == 1)
-                    Y = value;
-                else if (index == 2)
-                    Z = value;
-                else
-                    Scalar<T>.ThrowIndexOutOfRange();
-            }
         }
 
-        public readonly T Length => Scalar<T>.SquareRoot(LengthSquared);
+        public T Length => Scalar<T>.SquareRoot(LengthSquared);
 
-        public readonly T LengthSquared => Dot(this, this);
+        public T LengthSquared => Dot(this, this);
 
-        public readonly Vector3<T> Normalized() => Normalize(this);
-
-        public void Normalize()
-        {
-            this = Normalize(this);
-        }
+        public Vector3<T> Normalized() => Normalize(this);
 
         public static Vector3<T> Add(Vector3<T> a, Vector3<T> b)
         {
@@ -469,11 +459,11 @@ namespace Silk.NET.Maths
             return new Vector3<T>(values.X, values.Y, values.Z);
         }
 
-        public override readonly string ToString() => ToString("G");
+        public override string ToString() => ToString("G");
 
-        public readonly string ToString(string format) => ToString(format, CultureInfo.CurrentCulture);
+        public string ToString(string format) => ToString(format, CultureInfo.CurrentCulture);
         
-        public readonly string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string format, IFormatProvider formatProvider)
         {
             var sb = new StringBuilder();
             string separator = NumberFormatInfo.GetInstance(formatProvider).NumberGroupSeparator;
@@ -489,7 +479,7 @@ namespace Silk.NET.Maths
             return sb.ToString();
         }
 
-        public override readonly int GetHashCode()
+        public override int GetHashCode()
         {
             #if NETSTANDARD2_1
             return HashCode.Combine(X, Y, Z);
@@ -498,16 +488,16 @@ namespace Silk.NET.Maths
             #endif
         }
 
-        public override readonly bool Equals(object obj) => obj is Vector3<T> vec && Equals(vec);
+        public override bool Equals(object obj) => obj is Vector3<T> vec && Equals(vec);
 
-        public readonly bool Equals(Vector3<T> other)
+        public bool Equals(Vector3<T> other)
         {
             return Scalar<T>.Equal(X, other.X)
                    && Scalar<T>.Equal(Y, other.Y)
                    && Scalar<T>.Equal(Z, other.Z);
         }
 
-        public readonly void Deconstruct(out T x, out T y, out T z)
+        public void Deconstruct(out T x, out T y, out T z)
         {
             x = X;
             y = Y;
@@ -515,7 +505,7 @@ namespace Silk.NET.Maths
         }
 
 #if INTRINSICS 
-        public readonly Vector64<T> AsVector64()
+        public Vector64<T> AsVector64()
         {
             if (typeof(T) == typeof(byte))
             {
@@ -549,7 +539,7 @@ namespace Silk.NET.Maths
             return default;
         }
 
-        public readonly Vector128<T> AsVector128()
+        public Vector128<T> AsVector128()
         {
             if (typeof(T) == typeof(byte))
             {
@@ -595,7 +585,7 @@ namespace Silk.NET.Maths
             return default;
         }
 
-        public readonly Vector256<T> AsVector256()
+        public Vector256<T> AsVector256()
         {
             if (typeof(T) == typeof(byte))
             {
@@ -658,7 +648,7 @@ namespace Silk.NET.Maths
 #endif
 
 #if BTEC_INTRINSICS
-        public readonly unsafe Vector<T> AsVector()
+        public unsafe Vector<T> AsVector()
         { 
             if (Vector<T>.Count >= 3)
             {

--- a/src/Maths/Silk.NET.Maths/Vector4.cs
+++ b/src/Maths/Silk.NET.Maths/Vector4.cs
@@ -16,7 +16,7 @@ using System.Runtime.Intrinsics;
 namespace Silk.NET.Maths
 {
     [Serializable]
-    public struct Vector4<T> : IEquatable<Vector4<T>>, IFormattable where T : unmanaged, IFormattable
+    public readonly struct Vector4<T> : IEquatable<Vector4<T>>, IFormattable where T : unmanaged, IFormattable
     {
         public static Vector4<T> UnitX => new Vector4<T>(Scalar<T>.One, default, default, default);
         public static Vector4<T> UnitY => new Vector4<T>(default, Scalar<T>.One, default, default);
@@ -27,10 +27,11 @@ namespace Silk.NET.Maths
         public static Vector4<T> PositiveInfinity => new Vector4<T>(Scalar<T>.PositiveInfinity);
         public static Vector4<T> NegativeInfinity => new Vector4<T>(Scalar<T>.NegativeInfinity);
         public static unsafe int SizeInBytes => sizeof(Vector4<T>);
-        public T X;
-        public T Y;
-        public T Z;
-        public T W;
+        
+        public readonly T X;
+        public readonly T Y;
+        public readonly T Z;
+        public readonly T W;
 
         public Vector4(T value) : this(value, value, value, value)
         { }
@@ -57,10 +58,18 @@ namespace Silk.NET.Maths
         {
             this = xyzw;
         }
+        
+        public Vector4<T> WithX(T x) => new Vector4<T>(x, Y, Z, W);
+        
+        public Vector4<T> WithY(T y) => new Vector4<T>(X, y, Z, W);
+        
+        public Vector4<T> WithZ(T z) => new Vector4<T>(X, Y, z, W);
+        
+        public Vector4<T> WithW(T w) => new Vector4<T>(X, Y, Y, w);
 
         public T this[int index]
         {
-            readonly get
+            get
             {
                 if (index == 0)
                     return X;
@@ -77,19 +86,6 @@ namespace Silk.NET.Maths
                 Scalar<T>.ThrowIndexOutOfRange();
                 return default;
             }
-            set
-            {
-                if (index == 0)
-                    X = value;
-                else if (index == 1)
-                    Y = value;
-                else if (index == 2)
-                    Z = value;
-                else if (index == 3)
-                    W = value;
-                else
-                    Scalar<T>.ThrowIndexOutOfRange();
-            }
         }
 
         public T Length => Scalar<T>.SquareRoot(LengthSquared);
@@ -100,12 +96,7 @@ namespace Silk.NET.Maths
         {
             return Normalize(this);
         }
-
-        public void Normalize()
-        {
-            this = Normalized();
-        }
-
+        
         public static Vector4<T> Add(Vector4<T> a, Vector4<T> b)
         {
             return new Vector4<T>
@@ -552,7 +543,7 @@ namespace Silk.NET.Maths
             w = W;
         }
 #if INTRINSICS 
-        public readonly Vector64<T> AsVector64()
+        public Vector64<T> AsVector64()
         {
             if (typeof(T) == typeof(byte))
             {
@@ -586,7 +577,7 @@ namespace Silk.NET.Maths
             return default;
         }
 
-        public readonly Vector128<T> AsVector128()
+        public Vector128<T> AsVector128()
         {
             if (typeof(T) == typeof(byte))
             {
@@ -632,7 +623,7 @@ namespace Silk.NET.Maths
             return default;
         }
 
-        public readonly Vector256<T> AsVector256()
+        public Vector256<T> AsVector256()
         {
             if (typeof(T) == typeof(byte))
             {
@@ -695,7 +686,7 @@ namespace Silk.NET.Maths
 #endif
 
 #if BTEC_INTRINSICS
-        public readonly unsafe Vector<T> AsVector()
+        public unsafe Vector<T> AsVector()
         { 
             if (Vector<T>.Count >= 4)
             {

--- a/src/Maths/Silk.NET.Maths/Vector4.cs
+++ b/src/Maths/Silk.NET.Maths/Vector4.cs
@@ -92,11 +92,8 @@ namespace Silk.NET.Maths
 
         public T LengthSquared => Dot(this, this);
 
-        public Vector4<T> Normalized()
-        {
-            return Normalize(this);
-        }
-        
+        public Vector4<T> Normalize() => Normalize(this);
+
         public static Vector4<T> Add(Vector4<T> a, Vector4<T> b)
         {
             return new Vector4<T>


### PR DESCRIPTION
Simply making Vector2/3/4<T> `readonly` and removing the only non-readonly method `Normalize()` (also adds `WithX/Y/Z/W`)