### PR TITLE
#210 - Start of updating obsolete methods in example projects

### DIFF
--- a/examples/CSharp/Tutorial 1.1 - Hello Window/Tutorial 1.1 - Hello Window.csproj
+++ b/examples/CSharp/Tutorial 1.1 - Hello Window/Tutorial 1.1 - Hello Window.csproj
@@ -10,4 +10,8 @@
       <PackageReference Include="Silk.NET" Version="1.1.1" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/examples/CSharp/Tutorial 1.1 - Hello Window/Tutorial 1.1 - Hello Window.csproj
+++ b/examples/CSharp/Tutorial 1.1 - Hello Window/Tutorial 1.1 - Hello Window.csproj
@@ -1,14 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3.0</TargetFramework>
         <RootNamespace>Tutorial</RootNamespace>
     </PropertyGroup>
-
-    <ItemGroup>
-      <PackageReference Include="Silk.NET" Version="1.1.1" />
-    </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />

--- a/examples/CSharp/Tutorial 1.2 - Hello quad/Program.cs
+++ b/examples/CSharp/Tutorial 1.2 - Hello quad/Program.cs
@@ -83,7 +83,7 @@ namespace Tutorial
             }
 
             //Getting the opengl api for drawing to the screen.
-            Gl = GL.GetApi();
+            Gl = GL.GetApi(window);
 
             //Creating a vertex array.
             Vao = Gl.GenVertexArray();

--- a/examples/CSharp/Tutorial 1.2 - Hello quad/Tutorial 1.2 - Hello quad.csproj
+++ b/examples/CSharp/Tutorial 1.2 - Hello quad/Tutorial 1.2 - Hello quad.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Silk.NET" Version="1.1.1" />
+      <ProjectReference Include="..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
     </ItemGroup>
 
 </Project>

--- a/examples/CSharp/Tutorial 1.3 - Abstractions/Program.cs
+++ b/examples/CSharp/Tutorial 1.3 - Abstractions/Program.cs
@@ -58,7 +58,7 @@ namespace Tutorial
                 input.Keyboards[i].KeyDown += KeyDown;
             }
 
-            Gl = GL.GetApi();
+            Gl = GL.GetApi(window);
             
             //Instantiating our new abstractions
             Ebo = new BufferObject<uint>(Gl, Indices, BufferTargetARB.ElementArrayBuffer);

--- a/examples/CSharp/Tutorial 1.3 - Abstractions/Tutorial 1.3 - Abstraction.csproj
+++ b/examples/CSharp/Tutorial 1.3 - Abstractions/Tutorial 1.3 - Abstraction.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Silk.NET" Version="1.1.1" />
+      <ProjectReference Include="..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/Tutorial 1.4 - Textures/Program.cs
+++ b/examples/CSharp/Tutorial 1.4 - Textures/Program.cs
@@ -58,7 +58,7 @@ namespace Tutorial
                 input.Keyboards[i].KeyDown += KeyDown;
             }
 
-            Gl = GL.GetApi();
+            Gl = GL.GetApi(window);
             
             Ebo = new BufferObject<uint>(Gl, Indices, BufferTargetARB.ElementArrayBuffer);
             Vbo = new BufferObject<float>(Gl, Vertices, BufferTargetARB.ArrayBuffer);

--- a/examples/CSharp/Tutorial 1.4 - Textures/Texture.cs
+++ b/examples/CSharp/Tutorial 1.4 - Textures/Texture.cs
@@ -21,7 +21,7 @@ namespace Tutorial
             //where as openGL has origin in the bottom-left corner.
             img.Mutate(x => x.Flip(FlipMode.Vertical));
 
-            fixed (void* data = &MemoryMarshal.GetReference(img.GetPixelSpan()))
+            fixed (void* data = &MemoryMarshal.GetReference(img.GetPixelRowSpan(0)))
             {
                 //Loading the actual image.
                 Load(gl, data, (uint)img.Width, (uint)img.Height);

--- a/examples/CSharp/Tutorial 1.4 - Textures/Texture.cs
+++ b/examples/CSharp/Tutorial 1.4 - Textures/Texture.cs
@@ -3,7 +3,6 @@ using System;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using System.Runtime.InteropServices;
-using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.Processing;
 
 namespace Tutorial

--- a/examples/CSharp/Tutorial 1.4 - Textures/Tutorial 1.4 - Textures.csproj
+++ b/examples/CSharp/Tutorial 1.4 - Textures/Tutorial 1.4 - Textures.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-rc0003" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/Tutorial 1.4 - Textures/Tutorial 1.4 - Textures.csproj
+++ b/examples/CSharp/Tutorial 1.4 - Textures/Tutorial 1.4 - Textures.csproj
@@ -8,8 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Silk.NET" Version="1.1.1" />
       <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/Tutorial 1.5 - Transformations/Program.cs
+++ b/examples/CSharp/Tutorial 1.5 - Transformations/Program.cs
@@ -60,7 +60,7 @@ namespace Tutorial
                 input.Keyboards[i].KeyDown += KeyDown;
             }
 
-            Gl = GL.GetApi();
+            Gl = GL.GetApi(window);
             
             Ebo = new BufferObject<uint>(Gl, Indices, BufferTargetARB.ElementArrayBuffer);
             Vbo = new BufferObject<float>(Gl, Vertices, BufferTargetARB.ArrayBuffer);

--- a/examples/CSharp/Tutorial 1.5 - Transformations/Texture.cs
+++ b/examples/CSharp/Tutorial 1.5 - Transformations/Texture.cs
@@ -18,7 +18,7 @@ namespace Tutorial
             Image<Rgba32> img = (Image<Rgba32>)Image.Load(path);
             img.Mutate(x => x.Flip(FlipMode.Vertical));
 
-            fixed (void* data = &MemoryMarshal.GetReference(img.GetPixelSpan()))
+            fixed (void* data = &MemoryMarshal.GetReference(img.GetPixelRowSpan(0)))
             {
                 Load(gl, data, (uint)img.Width, (uint)img.Height);
             }

--- a/examples/CSharp/Tutorial 1.5 - Transformations/Tutorial 1.5 - Transformations.csproj
+++ b/examples/CSharp/Tutorial 1.5 - Transformations/Tutorial 1.5 - Transformations.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
+      <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-rc0003" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples/CSharp/Tutorial 1.5 - Transformations/Tutorial 1.5 - Transformations.csproj
+++ b/examples/CSharp/Tutorial 1.5 - Transformations/Tutorial 1.5 - Transformations.csproj
@@ -8,8 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Silk.NET" Version="1.1.1" />
       <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\src\Core\Silk.NET\Silk.NET.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Core/Silk.NET.Core/Silk.NET.Core.csproj
+++ b/src/Core/Silk.NET.Core/Silk.NET.Core.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
         <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-        <PackageReference Include="Ultz.SuperInvoke" Version="1.0.4" />
+        <PackageReference Include="Ultz.SuperInvoke" Version="1.1.0" />
     </ItemGroup>
 
     <Import Project="..\..\..\build\props\common.props" />


### PR DESCRIPTION
# Summary
Updates method calls in example projects to use non-deprecated versions of the method calls.

# Links
[#210 - Examples still use obsolete APIs](https://github.com/Ultz/Silk.NET/issues/210)