### PR TITLE
Update GLSymbolLoader to use the new, non-throwing load methods

### DIFF
--- a/src/Core/Silk.NET.Core/Core1.0/Loader/GLSymbolLoader.cs
+++ b/src/Core/Silk.NET.Core/Core1.0/Loader/GLSymbolLoader.cs
@@ -25,8 +25,7 @@ namespace Silk.NET.Core.Loader
         /// <returns>Pointer to the library.</returns>
         protected override IntPtr CoreLoadNativeLibrary(string name)
         {
-            var ret = IntPtr.Zero;
-            UnderlyingLoader.TryLoadNativeLibrary(name, out ret);
+            UnderlyingLoader.TryLoadNativeLibrary(name, out var ret);
             return ret;
         }
         

--- a/src/Core/Silk.NET.Core/Core1.0/Loader/GLSymbolLoader.cs
+++ b/src/Core/Silk.NET.Core/Core1.0/Loader/GLSymbolLoader.cs
@@ -23,7 +23,12 @@ namespace Silk.NET.Core.Loader
         /// </summary>
         /// <param name="name">The name of the library to load.</param>
         /// <returns>Pointer to the library.</returns>
-        protected override IntPtr CoreLoadNativeLibrary(string name) => UnderlyingLoader.LoadNativeLibrary(name);
+        protected override IntPtr CoreLoadNativeLibrary(string name)
+        {
+            var ret = IntPtr.Zero;
+            UnderlyingLoader.TryLoadNativeLibrary(name, out ret);
+            return ret;
+        }
         
         /// <summary>
         /// Free a native library.


### PR DESCRIPTION
# Summary of the PR
Fixes the first chance exceptions some users get (for good this time)

# Related issues, Discord discussions, or proposals
None that I know of

# Further Comments
This PR was done in my phone in GitHub web so I apologise if something went wrong.