### PR TITLE
.Net 5 Preview 6

### DIFF
--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -15,7 +15,7 @@ jobs:
 
   variables:
     buildConfiguration: 'Release'
-    dotnetCoreVersion: '5.0.100-preview.5.20279.10'
+    dotnetCoreVersion: '5.0.100-preview.6.20318.15'
 
   steps:
   - task: UseDotNet@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
 
   variables:
     buildConfiguration: 'Release'
-    dotnetCoreVersion: '5.0.100-preview.5.20279.10'
+    dotnetCoreVersion: '5.0.100-preview.6.20318.15'
 
   steps:
   - task: UseDotNet@2

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "5.0.100-preview.6.20318.15",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
Update CI to .Net 5 Preview 6
Also, create a `global.json`
See #236 for master update to `3.1.302` this will cause a merge conflict eventually if both are merged.