### PR TITLE
Throw exception when Glfw.Init fails.

### DIFF
--- a/src/Windowing/Silk.NET.GLFW/GlfwProvider.cs
+++ b/src/Windowing/Silk.NET.GLFW/GlfwProvider.cs
@@ -15,7 +15,7 @@ namespace Silk.NET.GLFW
         /// <summary>
         /// Creates a new instance of the GlfwProvider class.
         /// </summary>
-        static GlfwProvider()
+        unsafe static GlfwProvider()
         {
             GLFW = new Lazy<Glfw>
             (

--- a/src/Windowing/Silk.NET.GLFW/GlfwProvider.cs
+++ b/src/Windowing/Silk.NET.GLFW/GlfwProvider.cs
@@ -23,7 +23,14 @@ namespace Silk.NET.GLFW
                 {
 
                     var glfw = Glfw.GetApi();
-                    glfw.Init();
+
+                    if (!glfw.Init())
+                    {
+                        var code = (Silk.NET.GLFW.ErrorCode) glfw.GetError(out var pDesc);
+                        var desc = new string(pDesc);
+                        throw new GlfwException($"GLFW Init failed, {code}: {desc}");
+                    }
+
                     glfw.SetErrorCallback(Glfw.ErrorCallback);
 
                     return glfw;


### PR DESCRIPTION
# Summary of the PR
Checks the result of Glfw.Init, retrieves any error and throws instead of continuing.

# Related issues, Discord discussions, or proposals
#267 : Glfw.Init / glfwInit can fail silently

# Further Comments
...