### PR TITLE
Glfw.GetError has wrong parameter type (char* -> byte*)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Pack
       run: dotnet pack --configuration Release --version-suffix build$GITHUB_RUN_NUMBER.0
     - name: Setup NuGet
+      if: ${{ github.repository == 'Ultz/Silk.NET' && github.event_name != 'pull_request' }}
       uses: nuget/setup-nuget@v1
       with:
         nuget-version: '5.x'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,8 @@ jobs:
       with:
         nuget-version: '5.x'
     - name: Setup Feed
+      if: ${{ github.repository == 'Ultz/Silk.NET' && github.event_name != 'pull_request' }}
       run: nuget sources add -Name Experimental -Source https://pkgs.dev.azure.com/UltzOS/Silk.NET/_packaging/Experimental/nuget/v3/index.json -username ${{ secrets.AZDO_ARTIFACTS_USERNAME }} -password ${{ secrets.AZDO_ARTIFACTS_TOKEN }}
     - name: Push Experimental Packages
-      if: ${{ github.repository == 'Ultz/Silk.NET' }}
+      if: ${{ github.repository == 'Ultz/Silk.NET' && github.event_name != 'pull_request' }}
       run: nuget push "build/output_packages/*.nupkg" -Source Experimental -ApiKey ${{ secrets.AZDO_ARTIFACTS_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.302
+        dotnet-version: 3.1.401
     - name: Test
       run: dotnet test --verbosity normal
     - name: Pack

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.302
+        dotnet-version: 3.1.401
     - name: Install dependencies
       run: dotnet restore
     - name: Pack

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.302",
-    "rollForward": "latestPatch"
+    "version": "3.1",
+    "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1",
+    "version": "3.1.302",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Windowing/Silk.NET.GLFW/Glfw.cs
+++ b/src/Windowing/Silk.NET.GLFW/Glfw.cs
@@ -223,6 +223,26 @@ namespace Silk.NET.GLFW
         public abstract string GetVersionString();
 
         /// <summary>
+        /// Use <see cref="GetError(out byte*)"/> instead.
+        /// </summary>
+        /// <param name="description">
+        /// Where to store the error description pointer, or <c>out _</c>"/>.
+        /// This is actually a <see cref="byte"/> pointer.
+        /// </param>
+        /// <returns>The last error code for the calling thread, or <see cref="ErrorCode.NoError" /> (zero).</returns>
+        /// <remarks>
+        /// <para>
+        /// This method has an incorrect parameter type.
+        /// </para>
+        /// <para>
+        /// Will be removed in v2.0.
+        /// </para>
+        /// </remarks>
+        /// <seealso cref="GetError(out byte*)" />
+        [Obsolete("Use GetError(out byte* description) instead.")]
+        public abstract unsafe ErrorCode GetError(out char* description);
+
+        /// <summary>
         /// <para>
         /// This function returns and clears the error code of the last error that occurred on the calling thread,
         /// and optionally a UTF-8 encoded human-readable description of it.

--- a/src/Windowing/Silk.NET.GLFW/Glfw.cs
+++ b/src/Windowing/Silk.NET.GLFW/Glfw.cs
@@ -247,7 +247,7 @@ namespace Silk.NET.GLFW
         /// </para>
         /// </remarks>
         /// <seealso cref="SetErrorCallback" />
-        public abstract unsafe ErrorCode GetError(out char* description);
+        public abstract unsafe ErrorCode GetError(out byte* description);
 
         /// <summary>
         /// <para>

--- a/src/Windowing/Silk.NET.GLFW/GlfwProvider.cs
+++ b/src/Windowing/Silk.NET.GLFW/GlfwProvider.cs
@@ -15,7 +15,7 @@ namespace Silk.NET.GLFW
         /// <summary>
         /// Creates a new instance of the GlfwProvider class.
         /// </summary>
-        unsafe static GlfwProvider()
+        static unsafe GlfwProvider()
         {
             GLFW = new Lazy<Glfw>
             (
@@ -26,8 +26,10 @@ namespace Silk.NET.GLFW
 
                     if (!glfw.Init())
                     {
-                        var code = (Silk.NET.GLFW.ErrorCode) glfw.GetError(out var pDesc);
-                        var desc = new string(pDesc);
+                        var code = glfw.GetError(out var pDesc);
+                        // len = strnlen(pDesc, 4096);
+                        var len = new ReadOnlySpan<byte>(pDesc, 4096).IndexOf((byte)0);
+                        var desc = len <= 0 ? "Unknown" : System.Text.Encoding.UTF8.GetString(pDesc, len);
                         throw new GlfwException($"GLFW Init failed, {code}: {desc}");
                     }
 

--- a/src/Windowing/Silk.NET.GLFW/GlfwProvider.cs
+++ b/src/Windowing/Silk.NET.GLFW/GlfwProvider.cs
@@ -26,7 +26,7 @@ namespace Silk.NET.GLFW
 
                     if (!glfw.Init())
                     {
-                        var code = glfw.GetError(out var pDesc);
+                        var code = glfw.GetError(out byte* pDesc);
                         // len = strnlen(pDesc, 4096);
                         var len = new ReadOnlySpan<byte>(pDesc, 4096).IndexOf((byte)0);
                         var desc = len <= 0 ? "Unknown" : System.Text.Encoding.UTF8.GetString(pDesc, len);

--- a/src/Windowing/Silk.NET.GLFW/GlfwProvider.cs
+++ b/src/Windowing/Silk.NET.GLFW/GlfwProvider.cs
@@ -27,8 +27,7 @@ namespace Silk.NET.GLFW
                     if (!glfw.Init())
                     {
                         var code = glfw.GetError(out byte* pDesc);
-                        // len = strnlen(pDesc, 4096);
-                        var len = new ReadOnlySpan<byte>(pDesc, 4096).IndexOf((byte)0);
+                        var len = SpanHelpers.IndexOf(ref *pDesc, (byte)'\0', int.MaxValue);
                         var desc = len <= 0 ? "Unknown" : System.Text.Encoding.UTF8.GetString(pDesc, len);
                         throw new GlfwException($"GLFW Init failed, {code}: {desc}");
                     }

--- a/src/Windowing/Silk.NET.GLFW/GlfwProvider.cs
+++ b/src/Windowing/Silk.NET.GLFW/GlfwProvider.cs
@@ -27,7 +27,7 @@ namespace Silk.NET.GLFW
                     if (!glfw.Init())
                     {
                         var code = glfw.GetError(out byte* pDesc);
-                        var len = SpanHelpers.IndexOf(ref *pDesc, (byte)'\0', int.MaxValue);
+                        var len = new ReadOnlySpan<byte>(pDesc, int.MaxValue).IndexOf((byte)'\0');
                         var desc = len <= 0 ? "Unknown" : System.Text.Encoding.UTF8.GetString(pDesc, len);
                         throw new GlfwException($"GLFW Init failed, {code}: {desc}");
                     }


### PR DESCRIPTION
# Summary of the PR
Corrects Glfw.GetError parameter type.
Updates GlfwProvider static initializer to handle UTF8.

Introduced as non-breaking obsoleted change to API.
Breaking when obsolete method removed, targeting v2.0.

# Related issues, Discord discussions, or proposals
Discord discussions:
* [Meant to be out byte*, UTF8](https://discordapp.com/channels/521092042781229087/607634593201520651/743984606704959499)
* [Duplicate the endpoint and add [Obsolete] to prevent breaking change in master](https://discordapp.com/channels/521092042781229087/607634593201520651/743996982934241301)
* [Fix CI conditionals](https://discordapp.com/channels/521092042781229087/607634593201520651/743998958363213924)
* [Keep CI steps separate instead of merging](https://discordapp.com/channels/521092042781229087/607634593201520651/744000671669551192)

# Further Comments
CI adjusted to skip setting up and pushing packages for PRs.
Keeping pack step running on PRs because it threw an error when [the test step didn't](https://github.com/Ultz/Silk.NET/runs/986691976).