### PR TITLE
Fix exceptions being thrown when there is no error in the tutorials

### DIFF
--- a/examples/CSharp/Tutorial 1.2 - Hello quad/Program.cs
+++ b/examples/CSharp/Tutorial 1.2 - Hello quad/Program.cs
@@ -137,7 +137,8 @@ namespace Tutorial
 
             //Checking the linking for errors.
             string shader = Gl.GetProgramInfoLog(Shader);
-            if (!string.IsNullOrWhiteSpace(shader))
+            Gl.GetProgram(Shader, GLEnum.LinkStatus, out var status);
+            if (status == 0)
             {
                 Console.WriteLine($"Error linking shader {infoLog}");
             }

--- a/examples/CSharp/Tutorial 1.2 - Hello quad/Program.cs
+++ b/examples/CSharp/Tutorial 1.2 - Hello quad/Program.cs
@@ -136,11 +136,10 @@ namespace Tutorial
             Gl.LinkProgram(Shader);
 
             //Checking the linking for errors.
-            string shader = Gl.GetProgramInfoLog(Shader);
             Gl.GetProgram(Shader, GLEnum.LinkStatus, out var status);
             if (status == 0)
             {
-                Console.WriteLine($"Error linking shader {infoLog}");
+                Console.WriteLine($"Error linking shader {Gl.GetProgramInfoLog(Shader)}");
             }
 
             //Delete the no longer useful individual shaders;

--- a/examples/CSharp/Tutorial 1.3 - Abstractions/Shader.cs
+++ b/examples/CSharp/Tutorial 1.3 - Abstractions/Shader.cs
@@ -25,11 +25,10 @@ namespace Tutorial
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
             //Check for linking errors.
-            string infoLog = _gl.GetProgramInfoLog(_handle);
             _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
             if (status == 0)
             {
-                throw new Exception($"Program failed to link with error: {infoLog}");
+                throw new Exception($"Program failed to link with error: {_gl.GetProgramInfoLog(_handle)}");
             }
             //Detach and delete the shaders
             _gl.DetachShader(_handle, vertex);

--- a/examples/CSharp/Tutorial 1.3 - Abstractions/Shader.cs
+++ b/examples/CSharp/Tutorial 1.3 - Abstractions/Shader.cs
@@ -26,7 +26,8 @@ namespace Tutorial
             _gl.LinkProgram(_handle);
             //Check for linking errors.
             string infoLog = _gl.GetProgramInfoLog(_handle);
-            if (!string.IsNullOrWhiteSpace(infoLog))
+            _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
+            if (status == 0)
             {
                 throw new Exception($"Program failed to link with error: {infoLog}");
             }

--- a/examples/CSharp/Tutorial 1.4 - Textures/Shader.cs
+++ b/examples/CSharp/Tutorial 1.4 - Textures/Shader.cs
@@ -20,7 +20,8 @@ namespace Tutorial
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
             string infoLog = _gl.GetProgramInfoLog(_handle);
-            if (!string.IsNullOrWhiteSpace(infoLog))
+            _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
+            if (status == 0)
             {
                 throw new Exception($"Program failed to link with error: {infoLog}");
             }

--- a/examples/CSharp/Tutorial 1.4 - Textures/Shader.cs
+++ b/examples/CSharp/Tutorial 1.4 - Textures/Shader.cs
@@ -19,11 +19,10 @@ namespace Tutorial
             _gl.AttachShader(_handle, vertex);
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
-            string infoLog = _gl.GetProgramInfoLog(_handle);
             _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
             if (status == 0)
             {
-                throw new Exception($"Program failed to link with error: {infoLog}");
+                throw new Exception($"Program failed to link with error: {_gl.GetProgramInfoLog(_handle)}");
             }
             _gl.DetachShader(_handle, vertex);
             _gl.DetachShader(_handle, fragment);

--- a/examples/CSharp/Tutorial 1.5 - Transformations/Shader.cs
+++ b/examples/CSharp/Tutorial 1.5 - Transformations/Shader.cs
@@ -20,11 +20,10 @@ namespace Tutorial
             _gl.AttachShader(_handle, vertex);
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
-            string infoLog = _gl.GetProgramInfoLog(_handle);
             _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
             if (status == 0)
             {
-                throw new Exception($"Program failed to link with error: {infoLog}");
+                throw new Exception($"Program failed to link with error: {_gl.GetProgramInfoLog(_handle)}");
             }
             _gl.DetachShader(_handle, vertex);
             _gl.DetachShader(_handle, fragment);

--- a/examples/CSharp/Tutorial 1.5 - Transformations/Shader.cs
+++ b/examples/CSharp/Tutorial 1.5 - Transformations/Shader.cs
@@ -21,7 +21,8 @@ namespace Tutorial
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
             string infoLog = _gl.GetProgramInfoLog(_handle);
-            if (!string.IsNullOrWhiteSpace(infoLog))
+            _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
+            if (status == 0)
             {
                 throw new Exception($"Program failed to link with error: {infoLog}");
             }

--- a/examples/CSharp/Tutorial 2.1 - Co-ordinate Systems/Shader.cs
+++ b/examples/CSharp/Tutorial 2.1 - Co-ordinate Systems/Shader.cs
@@ -20,11 +20,10 @@ namespace Tutorial
             _gl.AttachShader(_handle, vertex);
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
-            string infoLog = _gl.GetProgramInfoLog(_handle);
             _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
             if (status == 0)
             {
-                throw new Exception($"Program failed to link with error: {infoLog}");
+                throw new Exception($"Program failed to link with error: {_gl.GetProgramInfoLog(_handle)}");
             }
             _gl.DetachShader(_handle, vertex);
             _gl.DetachShader(_handle, fragment);

--- a/examples/CSharp/Tutorial 2.1 - Co-ordinate Systems/Shader.cs
+++ b/examples/CSharp/Tutorial 2.1 - Co-ordinate Systems/Shader.cs
@@ -21,7 +21,8 @@ namespace Tutorial
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
             string infoLog = _gl.GetProgramInfoLog(_handle);
-            if (!string.IsNullOrWhiteSpace(infoLog))
+            _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
+            if (status == 0)
             {
                 throw new Exception($"Program failed to link with error: {infoLog}");
             }

--- a/examples/CSharp/Tutorial 2.2 - Camera/Shader.cs
+++ b/examples/CSharp/Tutorial 2.2 - Camera/Shader.cs
@@ -20,11 +20,10 @@ namespace Tutorial
             _gl.AttachShader(_handle, vertex);
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
-            string infoLog = _gl.GetProgramInfoLog(_handle);
             _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
             if (status == 0)
             {
-                throw new Exception($"Program failed to link with error: {infoLog}");
+                throw new Exception($"Program failed to link with error: {_gl.GetProgramInfoLog(_handle)}");
             }
             _gl.DetachShader(_handle, vertex);
             _gl.DetachShader(_handle, fragment);

--- a/examples/CSharp/Tutorial 2.2 - Camera/Shader.cs
+++ b/examples/CSharp/Tutorial 2.2 - Camera/Shader.cs
@@ -21,7 +21,8 @@ namespace Tutorial
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
             string infoLog = _gl.GetProgramInfoLog(_handle);
-            if (!string.IsNullOrWhiteSpace(infoLog))
+            _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
+            if (status == 0)
             {
                 throw new Exception($"Program failed to link with error: {infoLog}");
             }

--- a/examples/CSharp/Tutorial 3.1 - Ambient Lighting/Shader.cs
+++ b/examples/CSharp/Tutorial 3.1 - Ambient Lighting/Shader.cs
@@ -20,11 +20,10 @@ namespace Tutorial
             _gl.AttachShader(_handle, vertex);
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
-            string infoLog = _gl.GetProgramInfoLog(_handle);
             _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
             if (status == 0)
             {
-                throw new Exception($"Program failed to link with error: {infoLog}");
+                throw new Exception($"Program failed to link with error: {_gl.GetProgramInfoLog(_handle)}");
             }
             _gl.DetachShader(_handle, vertex);
             _gl.DetachShader(_handle, fragment);

--- a/examples/CSharp/Tutorial 3.1 - Ambient Lighting/Shader.cs
+++ b/examples/CSharp/Tutorial 3.1 - Ambient Lighting/Shader.cs
@@ -21,7 +21,8 @@ namespace Tutorial
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
             string infoLog = _gl.GetProgramInfoLog(_handle);
-            if (!string.IsNullOrWhiteSpace(infoLog))
+            _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
+            if (status == 0)
             {
                 throw new Exception($"Program failed to link with error: {infoLog}");
             }

--- a/examples/CSharp/Tutorial 3.2 - Diffuse Lighting/Shader.cs
+++ b/examples/CSharp/Tutorial 3.2 - Diffuse Lighting/Shader.cs
@@ -21,10 +21,12 @@ namespace Tutorial
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
             string infoLog = _gl.GetProgramInfoLog(_handle);
-            if (!string.IsNullOrWhiteSpace(infoLog))
+            _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
+            if (status == 0)
             {
                 throw new Exception($"Program failed to link with error: {infoLog}");
             }
+
             _gl.DetachShader(_handle, vertex);
             _gl.DetachShader(_handle, fragment);
             _gl.DeleteShader(vertex);

--- a/examples/CSharp/Tutorial 3.2 - Diffuse Lighting/Shader.cs
+++ b/examples/CSharp/Tutorial 3.2 - Diffuse Lighting/Shader.cs
@@ -20,11 +20,10 @@ namespace Tutorial
             _gl.AttachShader(_handle, vertex);
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
-            string infoLog = _gl.GetProgramInfoLog(_handle);
             _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
             if (status == 0)
             {
-                throw new Exception($"Program failed to link with error: {infoLog}");
+                throw new Exception($"Program failed to link with error: {_gl.GetProgramInfoLog(_handle)}");
             }
 
             _gl.DetachShader(_handle, vertex);

--- a/examples/CSharp/Tutorial 3.3 - Specular Lighting/Shader.cs
+++ b/examples/CSharp/Tutorial 3.3 - Specular Lighting/Shader.cs
@@ -20,11 +20,10 @@ namespace Tutorial
             _gl.AttachShader(_handle, vertex);
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
-            string infoLog = _gl.GetProgramInfoLog(_handle);
             _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
             if (status == 0)
             {
-                throw new Exception($"Program failed to link with error: {infoLog}");
+                throw new Exception($"Program failed to link with error: {_gl.GetProgramInfoLog(_handle)}");
             }
             _gl.DetachShader(_handle, vertex);
             _gl.DetachShader(_handle, fragment);

--- a/examples/CSharp/Tutorial 3.3 - Specular Lighting/Shader.cs
+++ b/examples/CSharp/Tutorial 3.3 - Specular Lighting/Shader.cs
@@ -21,7 +21,8 @@ namespace Tutorial
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
             string infoLog = _gl.GetProgramInfoLog(_handle);
-            if (!string.IsNullOrWhiteSpace(infoLog))
+            _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
+            if (status == 0)
             {
                 throw new Exception($"Program failed to link with error: {infoLog}");
             }

--- a/examples/CSharp/Tutorial 3.4 - Materials/Shader.cs
+++ b/examples/CSharp/Tutorial 3.4 - Materials/Shader.cs
@@ -20,11 +20,10 @@ namespace Tutorial
             _gl.AttachShader(_handle, vertex);
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
-            string infoLog = _gl.GetProgramInfoLog(_handle);
             _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
             if (status == 0)
             {
-                throw new Exception($"Program failed to link with error: {infoLog}");
+                throw new Exception($"Program failed to link with error: {_gl.GetProgramInfoLog(_handle)}");
             }
             _gl.DetachShader(_handle, vertex);
             _gl.DetachShader(_handle, fragment);

--- a/examples/CSharp/Tutorial 3.4 - Materials/Shader.cs
+++ b/examples/CSharp/Tutorial 3.4 - Materials/Shader.cs
@@ -21,7 +21,8 @@ namespace Tutorial
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
             string infoLog = _gl.GetProgramInfoLog(_handle);
-            if (!string.IsNullOrWhiteSpace(infoLog))
+            _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
+            if (status == 0)
             {
                 throw new Exception($"Program failed to link with error: {infoLog}");
             }

--- a/examples/CSharp/Tutorial 3.5 - Lighting Maps/Shader.cs
+++ b/examples/CSharp/Tutorial 3.5 - Lighting Maps/Shader.cs
@@ -20,11 +20,10 @@ namespace Tutorial
             _gl.AttachShader(_handle, vertex);
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
-            string infoLog = _gl.GetProgramInfoLog(_handle);
             _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
             if (status == 0)
             {
-                throw new Exception($"Program failed to link with error: {infoLog}");
+                throw new Exception($"Program failed to link with error: {_gl.GetProgramInfoLog(_handle)}");
             }
             _gl.DetachShader(_handle, vertex);
             _gl.DetachShader(_handle, fragment);

--- a/examples/CSharp/Tutorial 3.5 - Lighting Maps/Shader.cs
+++ b/examples/CSharp/Tutorial 3.5 - Lighting Maps/Shader.cs
@@ -21,7 +21,8 @@ namespace Tutorial
             _gl.AttachShader(_handle, fragment);
             _gl.LinkProgram(_handle);
             string infoLog = _gl.GetProgramInfoLog(_handle);
-            if (!string.IsNullOrWhiteSpace(infoLog))
+            _gl.GetProgram(_handle, GLEnum.LinkStatus, out var status);
+            if (status == 0)
             {
                 throw new Exception($"Program failed to link with error: {infoLog}");
             }


### PR DESCRIPTION
# Summary of the PR
Previously, we were throwing an exception if any info log was posted by the GL driver, which means we were throwing for non-breaking warnings. This PR changes the tutorials to use glGetProgram to determine if linking was successful before throwing any exceptions.

# Related issues, Discord discussions, or proposals
Closes #270 

# Further Comments
cc @RhysWhy for future tutorials