### PR TITLE
WindowOptions will use Resolution of VideoMode

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Common/WindowOptions.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/WindowOptions.cs
@@ -22,7 +22,7 @@ namespace Silk.NET.Windowing.Common
             IsVisible = true;
             UseSingleThreadedWindow = opts.UseSingleThreadedWindow;
             Position = new Point(50, 50);
-            Size = new Size(1280, 720);
+            Size = opts.VideoMode.Resolution ?? new Size(1280, 720);
             FramesPerSecond = opts.FramesPerSecond;
             UpdatesPerSecond = opts.UpdatesPerSecond;
             API = opts.API;


### PR DESCRIPTION
`WindowOptions` constructor with existing `ViewOptions` did not use the
Resolution of the `ViewMode` from the `ViewOptions` and defaulted to
1280x720.
