### PR TITLE
Type Specialization

### DIFF
--- a/.github/workflows/maths-ci.yml
+++ b/.github/workflows/maths-ci.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.100-preview.7.20366.6
+        dotnet-version: 5.0.100-rc.1.20452.10
     - name: Run Tests and Export NUnit
       run: dotnet test ./src/Maths/Silk.NET.Maths.Tests/Silk.NET.Maths.Tests.fsproj -c Release -f net5.0 -l GitHubActions
   Coverage:
@@ -26,7 +26,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with: 
-        dotnet-version: 5.0.100-preview.7.20366.6
+        dotnet-version: 5.0.100-rc.1.20452.10
     - name: Collect coverage
       run: dotnet test ./src/Maths/Silk.NET.Maths.Tests/Silk.NET.Maths.Tests.fsproj --configuration Release /p:AltCover=true /p:AltCoverCobertura="cobertura.xml"
     - uses: codecov/codecov-action@v1

--- a/.github/workflows/maths-jit-diff.yml
+++ b/.github/workflows/maths-jit-diff.yml
@@ -13,8 +13,8 @@ on:
 
 env:
   DOTNET_NOLOGO: 1
-  DOTNET_TAG: v5.0.0-preview.7.20364.11
-  DOTNET_VERSION: 5.0.100-preview.7.20366.6
+  DOTNET_TAG: v5.0.0-rc.1.20451.14
+  DOTNET_VERSION: 5.0.100-rc.1.20452.10
 
 jobs:
   check-comment:

--- a/build/maths/windows-jit-asm-x64
+++ b/build/maths/windows-jit-asm-x64
@@ -1037,7 +1037,7 @@ G_M28871_IG02:
 ; Final local variable assignments
 ;
 ;# V00 OutArgs      [V00    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V01 tmp1         [V01,T00] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -1061,7 +1061,7 @@ G_M19083_IG03:
 ; Final local variable assignments
 ;
 ;# V00 OutArgs      [V00    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V01 tmp1         [V01,T00] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -1086,7 +1086,7 @@ G_M62371_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )   ubyte  ->  zero-ref   
 ;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V02 tmp1         [V02,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -1436,65 +1436,36 @@ G_M32304_IG03:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )   ubyte  ->  rcx        
 ;  V01 arg1         [V01,T01] (  3,  3   )   ubyte  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M59209_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M59209_IG02:
-       movzx    rcx, cl
-       movzx    rdx, dl
-       call     Silk.NET.Maths.Scalar:Min(ubyte,ubyte):ubyte
-       nop      
-						;; bbWeight=1    PerfScore 1.75
-G_M59209_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 21, prolog size 4, PerfScore 5.35, (MethodHash=5c4118b6) for method JITTest.ScalarByte:Min(ubyte,ubyte):ubyte
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(ubyte,ubyte):ubyte
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )   ubyte  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )   ubyte  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T04] (  3,  2   )   ubyte  ->  rdx         "Inline return value spill temp"
-;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
-;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;* V03 tmp1         [V03    ] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T04] (  3,  2   )   ubyte  ->  rdx         "Inline return value spill temp"
+;  V05 cse0         [V05,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V06 cse1         [V06,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
-G_M13475_IG01:
+G_M59209_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M13475_IG02:
+G_M59209_IG02:
        movzx    rax, cl
        movzx    rdx, dl
        cmp      eax, edx
-       jle      SHORT G_M13475_IG04
+       jle      SHORT G_M59209_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M13475_IG03:
-       jmp      SHORT G_M13475_IG05
+G_M59209_IG03:
+       jmp      SHORT G_M59209_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M13475_IG04:
+G_M59209_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M13475_IG05:
+G_M59209_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M13475_IG06:
+G_M59209_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 17, prolog size 0, PerfScore 5.83, (MethodHash=ac01cb5c) for method Silk.NET.Maths.Scalar:Min(ubyte,ubyte):ubyte
+; Total bytes of code 17, prolog size 0, PerfScore 5.83, (MethodHash=5c4118b6) for method JITTest.ScalarByte:Min(ubyte,ubyte):ubyte
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarByte:Max(ubyte,ubyte):ubyte
@@ -1506,65 +1477,36 @@ G_M13475_IG06:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )   ubyte  ->  rcx        
 ;  V01 arg1         [V01,T01] (  3,  3   )   ubyte  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M5143_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M5143_IG02:
-       movzx    rcx, cl
-       movzx    rdx, dl
-       call     Silk.NET.Maths.Scalar:Max(ubyte,ubyte):ubyte
-       nop      
-						;; bbWeight=1    PerfScore 1.75
-G_M5143_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 21, prolog size 4, PerfScore 5.35, (MethodHash=0e69ebe8) for method JITTest.ScalarByte:Max(ubyte,ubyte):ubyte
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(ubyte,ubyte):ubyte
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )   ubyte  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )   ubyte  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T04] (  3,  2   )   ubyte  ->  rdx         "Inline return value spill temp"
-;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
-;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;* V03 tmp1         [V03    ] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T04] (  3,  2   )   ubyte  ->  rdx         "Inline return value spill temp"
+;  V05 cse0         [V05,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V06 cse1         [V06,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
-G_M12541_IG01:
+G_M5143_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M12541_IG02:
+G_M5143_IG02:
        movzx    rax, cl
        movzx    rdx, dl
        cmp      eax, edx
-       jge      SHORT G_M12541_IG04
+       jge      SHORT G_M5143_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M12541_IG03:
-       jmp      SHORT G_M12541_IG05
+G_M5143_IG03:
+       jmp      SHORT G_M5143_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M12541_IG04:
+G_M5143_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M12541_IG05:
+G_M5143_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M12541_IG06:
+G_M5143_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 17, prolog size 0, PerfScore 5.83, (MethodHash=2d41cf02) for method Silk.NET.Maths.Scalar:Max(ubyte,ubyte):ubyte
+; Total bytes of code 17, prolog size 0, PerfScore 5.83, (MethodHash=0e69ebe8) for method JITTest.ScalarByte:Max(ubyte,ubyte):ubyte
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarByte:Larger(ubyte,ubyte):bool
@@ -1725,7 +1667,7 @@ G_M17859_IG03:
 ; Total bytes of code 39, prolog size 5, PerfScore 10.40, (MethodHash=4545ba3c) for method JITTest.ScalarByte:Clamp(ubyte,ubyte,ubyte):ubyte
 ; ============================================================
 
-; Assembly listing for method JITTest.ScalarByte:Negate(ubyte):ubyte
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(ubyte,ubyte):ubyte
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
 ; rsp based frame
@@ -1733,27 +1675,79 @@ G_M17859_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )   ubyte  ->  rcx        
-;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
+;  V01 arg1         [V01,T01] (  3,  3   )   ubyte  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V03 tmp1         [V03,T04] (  3,  2   )   ubyte  ->  rdx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
 ;
-; Lcl frame size = 40
+; Lcl frame size = 0
 
-G_M26380_IG01:
-       sub      rsp, 40
+G_M12541_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M12541_IG02:
+       movzx    rax, cl
+       movzx    rdx, dl
+       cmp      eax, edx
+       jge      SHORT G_M12541_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M12541_IG03:
+       jmp      SHORT G_M12541_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M12541_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M12541_IG05:
+       mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M26380_IG02:
-       movzx    rcx, cl
-       call     Silk.NET.Maths.Scalar:Negate(ubyte):ubyte
-       nop      
-						;; bbWeight=1    PerfScore 1.50
-G_M26380_IG03:
-       add      rsp, 40
+G_M12541_IG06:
        ret      
-						;; bbWeight=1    PerfScore 1.25
+						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 18, prolog size 4, PerfScore 4.80, (MethodHash=adaf98f3) for method JITTest.ScalarByte:Negate(ubyte):ubyte
+; Total bytes of code 17, prolog size 0, PerfScore 5.83, (MethodHash=2d41cf02) for method Silk.NET.Maths.Scalar:Max(ubyte,ubyte):ubyte
 ; ============================================================
 
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(ubyte):ubyte
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(ubyte,ubyte):ubyte
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  3,  3   )   ubyte  ->  rcx        
+;  V01 arg1         [V01,T01] (  3,  3   )   ubyte  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V03 tmp1         [V03,T04] (  3,  2   )   ubyte  ->  rdx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M13475_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M13475_IG02:
+       movzx    rax, cl
+       movzx    rdx, dl
+       cmp      eax, edx
+       jle      SHORT G_M13475_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M13475_IG03:
+       jmp      SHORT G_M13475_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M13475_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M13475_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M13475_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 17, prolog size 0, PerfScore 5.83, (MethodHash=ac01cb5c) for method Silk.NET.Maths.Scalar:Min(ubyte,ubyte):ubyte
+; ============================================================
+
+; Assembly listing for method JITTest.ScalarByte:Negate(ubyte):ubyte
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
 ; rsp based frame
@@ -1761,20 +1755,21 @@ G_M26380_IG03:
 ; Final local variable assignments
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )   ubyte  ->  zero-ref   
-;* V01 loc0         [V01    ] (  0,  0   )   ubyte  ->  zero-ref    ld-addr-op
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
+;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
+;* V02 tmp1         [V02    ] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp2         [V03    ] (  0,  0   )   ubyte  ->  zero-ref    ld-addr-op "Inline ldloca(s) first use temp"
 ;
 ; Lcl frame size = 40
 
-G_M58726_IG01:
+G_M26380_IG01:
        sub      rsp, 40
 						;; bbWeight=1    PerfScore 0.25
-G_M58726_IG02:
+G_M26380_IG02:
        call     Silk.NET.Maths.Scalar:ThrowInvalidType()
        int3     
 						;; bbWeight=0    PerfScore 0.00
 
-; Total bytes of code 10, prolog size 4, PerfScore 1.25, (MethodHash=530f1a99) for method Silk.NET.Maths.Scalar:Negate(ubyte):ubyte
+; Total bytes of code 10, prolog size 4, PerfScore 1.25, (MethodHash=adaf98f3) for method JITTest.ScalarByte:Negate(ubyte):ubyte
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarByte:Equal(ubyte,ubyte):bool
@@ -2899,7 +2894,7 @@ G_M6740_IG02:
 ; Final local variable assignments
 ;
 ;# V00 OutArgs      [V00    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V01 tmp1         [V01,T00] (  0,  0   )    byte  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )    byte  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -2923,7 +2918,7 @@ G_M16493_IG03:
 ; Final local variable assignments
 ;
 ;# V00 OutArgs      [V00    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V01 tmp1         [V01,T00] (  0,  0   )    byte  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )    byte  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -2948,7 +2943,7 @@ G_M25605_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )    byte  ->  zero-ref   
 ;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V02 tmp1         [V02,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -3298,65 +3293,36 @@ G_M18614_IG03:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  rcx        
 ;  V01 arg1         [V01,T01] (  3,  3   )    byte  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M38415_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M38415_IG02:
-       movsx    rcx, cl
-       movsx    rdx, dl
-       call     Silk.NET.Maths.Scalar:Min(byte,byte):byte
-       nop      
-						;; bbWeight=1    PerfScore 1.75
-G_M38415_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 23, prolog size 4, PerfScore 5.55, (MethodHash=b61169f0) for method JITTest.ScalarSByte:Min(byte,byte):byte
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(byte,byte):byte
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )    byte  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T04] (  3,  2   )    byte  ->  rdx         "Inline return value spill temp"
-;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
-;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;* V03 tmp1         [V03    ] (  0,  0   )    byte  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T04] (  3,  2   )    byte  ->  rdx         "Inline return value spill temp"
+;  V05 cse0         [V05,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V06 cse1         [V06,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
-G_M1654_IG01:
+G_M38415_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M1654_IG02:
+G_M38415_IG02:
        movsx    rax, cl
        movsx    rdx, dl
        cmp      eax, edx
-       jle      SHORT G_M1654_IG04
+       jle      SHORT G_M38415_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M1654_IG03:
-       jmp      SHORT G_M1654_IG05
+G_M38415_IG03:
+       jmp      SHORT G_M38415_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M1654_IG04:
+G_M38415_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M1654_IG05:
+G_M38415_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M1654_IG06:
+G_M38415_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 19, prolog size 0, PerfScore 6.03, (MethodHash=9c4bf989) for method Silk.NET.Maths.Scalar:Min(byte,byte):byte
+; Total bytes of code 19, prolog size 0, PerfScore 6.03, (MethodHash=b61169f0) for method JITTest.ScalarSByte:Min(byte,byte):byte
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarSByte:Max(byte,byte):byte
@@ -3368,65 +3334,36 @@ G_M1654_IG06:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  rcx        
 ;  V01 arg1         [V01,T01] (  3,  3   )    byte  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M51473_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M51473_IG02:
-       movsx    rcx, cl
-       movsx    rdx, dl
-       call     Silk.NET.Maths.Scalar:Max(byte,byte):byte
-       nop      
-						;; bbWeight=1    PerfScore 1.75
-G_M51473_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 23, prolog size 4, PerfScore 5.55, (MethodHash=578236ee) for method JITTest.ScalarSByte:Max(byte,byte):byte
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(byte,byte):byte
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )    byte  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T04] (  3,  2   )    byte  ->  rdx         "Inline return value spill temp"
-;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
-;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;* V03 tmp1         [V03    ] (  0,  0   )    byte  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T04] (  3,  2   )    byte  ->  rdx         "Inline return value spill temp"
+;  V05 cse0         [V05,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V06 cse1         [V06,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
-G_M4456_IG01:
+G_M51473_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M4456_IG02:
+G_M51473_IG02:
        movsx    rax, cl
        movsx    rdx, dl
        cmp      eax, edx
-       jge      SHORT G_M4456_IG04
+       jge      SHORT G_M51473_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M4456_IG03:
-       jmp      SHORT G_M4456_IG05
+G_M51473_IG03:
+       jmp      SHORT G_M51473_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M4456_IG04:
+G_M51473_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M4456_IG05:
+G_M51473_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M4456_IG06:
+G_M51473_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 19, prolog size 0, PerfScore 6.03, (MethodHash=bb37ee97) for method Silk.NET.Maths.Scalar:Max(byte,byte):byte
+; Total bytes of code 19, prolog size 0, PerfScore 6.03, (MethodHash=578236ee) for method JITTest.ScalarSByte:Max(byte,byte):byte
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarSByte:Larger(byte,byte):bool
@@ -3587,6 +3524,86 @@ G_M54704_IG03:
 ; Total bytes of code 42, prolog size 5, PerfScore 10.70, (MethodHash=f0792a4f) for method JITTest.ScalarSByte:Clamp(byte,byte,byte):byte
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(byte,byte):byte
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  rcx        
+;  V01 arg1         [V01,T01] (  3,  3   )    byte  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V03 tmp1         [V03,T04] (  3,  2   )    byte  ->  rdx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M4456_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M4456_IG02:
+       movsx    rax, cl
+       movsx    rdx, dl
+       cmp      eax, edx
+       jge      SHORT G_M4456_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M4456_IG03:
+       jmp      SHORT G_M4456_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M4456_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M4456_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M4456_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 19, prolog size 0, PerfScore 6.03, (MethodHash=bb37ee97) for method Silk.NET.Maths.Scalar:Max(byte,byte):byte
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(byte,byte):byte
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  rcx        
+;  V01 arg1         [V01,T01] (  3,  3   )    byte  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V03 tmp1         [V03,T04] (  3,  2   )    byte  ->  rdx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M1654_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M1654_IG02:
+       movsx    rax, cl
+       movsx    rdx, dl
+       cmp      eax, edx
+       jle      SHORT G_M1654_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M1654_IG03:
+       jmp      SHORT G_M1654_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M1654_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M1654_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M1654_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 19, prolog size 0, PerfScore 6.03, (MethodHash=9c4bf989) for method Silk.NET.Maths.Scalar:Min(byte,byte):byte
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarSByte:Negate(byte):byte
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
@@ -3595,51 +3612,23 @@ G_M54704_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  rcx        
-;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M19743_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M19743_IG02:
-       movsx    rcx, cl
-       call     Silk.NET.Maths.Scalar:Negate(byte):byte
-       nop      
-						;; bbWeight=1    PerfScore 1.50
-G_M19743_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 19, prolog size 4, PerfScore 4.90, (MethodHash=3bb5b2e0) for method JITTest.ScalarSByte:Negate(byte):byte
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(byte):byte
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  rcx        
-;* V01 loc0         [V01    ] (  0,  0   )    byte  ->  zero-ref    ld-addr-op
-;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V02 tmp1         [V02,T01] (  2,  2   )    byte  ->  rax         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M23654_IG01:
+G_M19743_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M23654_IG02:
+G_M19743_IG02:
        movsx    rax, cl
        neg      eax
        movsx    rax, al
 						;; bbWeight=1    PerfScore 0.75
-G_M23654_IG03:
+G_M19743_IG03:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 11, prolog size 0, PerfScore 2.85, (MethodHash=749da399) for method Silk.NET.Maths.Scalar:Negate(byte):byte
+; Total bytes of code 11, prolog size 0, PerfScore 2.85, (MethodHash=3bb5b2e0) for method JITTest.ScalarSByte:Negate(byte):byte
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarSByte:Equal(byte,byte):bool
@@ -4774,7 +4763,7 @@ G_M59018_IG02:
 ; Final local variable assignments
 ;
 ;# V00 OutArgs      [V00    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V01 tmp1         [V01,T00] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -4798,7 +4787,7 @@ G_M13342_IG03:
 ; Final local variable assignments
 ;
 ;# V00 OutArgs      [V00    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V01 tmp1         [V01,T00] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -4823,7 +4812,7 @@ G_M52406_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )  ushort  ->  zero-ref   
 ;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V02 tmp1         [V02,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -5173,65 +5162,36 @@ G_M18149_IG03:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )  ushort  ->  rcx        
 ;  V01 arg1         [V01,T01] (  3,  3   )  ushort  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M41244_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M41244_IG02:
-       movzx    rcx, cx
-       movzx    rdx, dx
-       call     Silk.NET.Maths.Scalar:Min(ushort,ushort):ushort
-       nop      
-						;; bbWeight=1    PerfScore 1.75
-G_M41244_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 21, prolog size 4, PerfScore 5.35, (MethodHash=779f5ee3) for method JITTest.ScalarUShort:Min(ushort,ushort):ushort
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(ushort,ushort):ushort
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )  ushort  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )  ushort  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T04] (  3,  2   )  ushort  ->  rdx         "Inline return value spill temp"
-;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
-;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;* V03 tmp1         [V03    ] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T04] (  3,  2   )  ushort  ->  rdx         "Inline return value spill temp"
+;  V05 cse0         [V05,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V06 cse1         [V06,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
-G_M4923_IG01:
+G_M41244_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M4923_IG02:
+G_M41244_IG02:
        movzx    rax, cx
        movzx    rdx, dx
        cmp      eax, edx
-       jle      SHORT G_M4923_IG04
+       jle      SHORT G_M41244_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M4923_IG03:
-       jmp      SHORT G_M4923_IG05
+G_M41244_IG03:
+       jmp      SHORT G_M41244_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M4923_IG04:
+G_M41244_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M4923_IG05:
+G_M41244_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M4923_IG06:
+G_M41244_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 17, prolog size 0, PerfScore 5.83, (MethodHash=35e3ecc4) for method Silk.NET.Maths.Scalar:Min(ushort,ushort):ushort
+; Total bytes of code 17, prolog size 0, PerfScore 5.83, (MethodHash=779f5ee3) for method JITTest.ScalarUShort:Min(ushort,ushort):ushort
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUShort:Max(ushort,ushort):ushort
@@ -5243,65 +5203,36 @@ G_M4923_IG06:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )  ushort  ->  rcx        
 ;  V01 arg1         [V01,T01] (  3,  3   )  ushort  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M41986_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M41986_IG02:
-       movzx    rcx, cx
-       movzx    rdx, dx
-       call     Silk.NET.Maths.Scalar:Max(ushort,ushort):ushort
-       nop      
-						;; bbWeight=1    PerfScore 1.75
-G_M41986_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 21, prolog size 4, PerfScore 5.35, (MethodHash=76385bfd) for method JITTest.ScalarUShort:Max(ushort,ushort):ushort
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(ushort,ushort):ushort
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )  ushort  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )  ushort  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T04] (  3,  2   )  ushort  ->  rdx         "Inline return value spill temp"
-;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
-;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;* V03 tmp1         [V03    ] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T04] (  3,  2   )  ushort  ->  rdx         "Inline return value spill temp"
+;  V05 cse0         [V05,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V06 cse1         [V06,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
-G_M805_IG01:
+G_M41986_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M805_IG02:
+G_M41986_IG02:
        movzx    rax, cx
        movzx    rdx, dx
        cmp      eax, edx
-       jge      SHORT G_M805_IG04
+       jge      SHORT G_M41986_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M805_IG03:
-       jmp      SHORT G_M805_IG05
+G_M41986_IG03:
+       jmp      SHORT G_M41986_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M805_IG04:
+G_M41986_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M805_IG05:
+G_M41986_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M805_IG06:
+G_M41986_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 17, prolog size 0, PerfScore 5.83, (MethodHash=c73bfcda) for method Silk.NET.Maths.Scalar:Max(ushort,ushort):ushort
+; Total bytes of code 17, prolog size 0, PerfScore 5.83, (MethodHash=76385bfd) for method JITTest.ScalarUShort:Max(ushort,ushort):ushort
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUShort:Larger(ushort,ushort):bool
@@ -5462,7 +5393,7 @@ G_M59470_IG03:
 ; Total bytes of code 38, prolog size 5, PerfScore 10.30, (MethodHash=7db317b1) for method JITTest.ScalarUShort:Clamp(ushort,ushort,ushort):ushort
 ; ============================================================
 
-; Assembly listing for method JITTest.ScalarUShort:Negate(ushort):ushort
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(ushort,ushort):ushort
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
 ; rsp based frame
@@ -5470,27 +5401,79 @@ G_M59470_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )  ushort  ->  rcx        
-;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
+;  V01 arg1         [V01,T01] (  3,  3   )  ushort  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V03 tmp1         [V03,T04] (  3,  2   )  ushort  ->  rdx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
 ;
-; Lcl frame size = 40
+; Lcl frame size = 0
 
-G_M52289_IG01:
-       sub      rsp, 40
+G_M805_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M805_IG02:
+       movzx    rax, cx
+       movzx    rdx, dx
+       cmp      eax, edx
+       jge      SHORT G_M805_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M805_IG03:
+       jmp      SHORT G_M805_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M805_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M805_IG05:
+       mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M52289_IG02:
-       movzx    rcx, cx
-       call     Silk.NET.Maths.Scalar:Negate(ushort):ushort
-       nop      
-						;; bbWeight=1    PerfScore 1.50
-G_M52289_IG03:
-       add      rsp, 40
+G_M805_IG06:
        ret      
-						;; bbWeight=1    PerfScore 1.25
+						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 18, prolog size 4, PerfScore 4.80, (MethodHash=358e33be) for method JITTest.ScalarUShort:Negate(ushort):ushort
+; Total bytes of code 17, prolog size 0, PerfScore 5.83, (MethodHash=c73bfcda) for method Silk.NET.Maths.Scalar:Max(ushort,ushort):ushort
 ; ============================================================
 
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(ushort):ushort
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(ushort,ushort):ushort
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  3,  3   )  ushort  ->  rcx        
+;  V01 arg1         [V01,T01] (  3,  3   )  ushort  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V03 tmp1         [V03,T04] (  3,  2   )  ushort  ->  rdx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M4923_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M4923_IG02:
+       movzx    rax, cx
+       movzx    rdx, dx
+       cmp      eax, edx
+       jle      SHORT G_M4923_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M4923_IG03:
+       jmp      SHORT G_M4923_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M4923_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M4923_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M4923_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 17, prolog size 0, PerfScore 5.83, (MethodHash=35e3ecc4) for method Silk.NET.Maths.Scalar:Min(ushort,ushort):ushort
+; ============================================================
+
+; Assembly listing for method JITTest.ScalarUShort:Negate(ushort):ushort
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
 ; rsp based frame
@@ -5498,20 +5481,21 @@ G_M52289_IG03:
 ; Final local variable assignments
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )  ushort  ->  zero-ref   
-;* V01 loc0         [V01    ] (  0,  0   )  ushort  ->  zero-ref    ld-addr-op
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
+;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
+;* V02 tmp1         [V02    ] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp2         [V03    ] (  0,  0   )  ushort  ->  zero-ref    ld-addr-op "Inline ldloca(s) first use temp"
 ;
 ; Lcl frame size = 40
 
-G_M11110_IG01:
+G_M52289_IG01:
        sub      rsp, 40
 						;; bbWeight=1    PerfScore 0.25
-G_M11110_IG02:
+G_M52289_IG02:
        call     Silk.NET.Maths.Scalar:ThrowInvalidType()
        int3     
 						;; bbWeight=0    PerfScore 0.00
 
-; Total bytes of code 10, prolog size 4, PerfScore 1.25, (MethodHash=ec21d499) for method Silk.NET.Maths.Scalar:Negate(ushort):ushort
+; Total bytes of code 10, prolog size 4, PerfScore 1.25, (MethodHash=358e33be) for method JITTest.ScalarUShort:Negate(ushort):ushort
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUShort:Equal(ushort,ushort):bool
@@ -6636,7 +6620,7 @@ G_M63071_IG02:
 ; Final local variable assignments
 ;
 ;# V00 OutArgs      [V00    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V01 tmp1         [V01,T00] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -6660,7 +6644,7 @@ G_M34686_IG03:
 ; Final local variable assignments
 ;
 ;# V00 OutArgs      [V00    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V01 tmp1         [V01,T00] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -6685,7 +6669,7 @@ G_M42262_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )   short  ->  zero-ref   
 ;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V02 tmp1         [V02,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -7035,65 +7019,36 @@ G_M17157_IG03:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  rcx        
 ;  V01 arg1         [V01,T01] (  3,  3   )   short  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M55292_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M55292_IG02:
-       movsx    rcx, cx
-       movsx    rdx, dx
-       call     Silk.NET.Maths.Scalar:Min(short,short):short
-       nop      
-						;; bbWeight=1    PerfScore 1.75
-G_M55292_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 23, prolog size 4, PerfScore 5.55, (MethodHash=7a272803) for method JITTest.ScalarShort:Min(short,short):short
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(short,short):short
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )   short  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T04] (  3,  2   )   short  ->  rdx         "Inline return value spill temp"
-;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
-;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;* V03 tmp1         [V03    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T04] (  3,  2   )   short  ->  rdx         "Inline return value spill temp"
+;  V05 cse0         [V05,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V06 cse1         [V06,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
-G_M12462_IG01:
+G_M55292_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M12462_IG02:
+G_M55292_IG02:
        movsx    rax, cx
        movsx    rdx, dx
        cmp      eax, edx
-       jle      SHORT G_M12462_IG04
+       jle      SHORT G_M55292_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M12462_IG03:
-       jmp      SHORT G_M12462_IG05
+G_M55292_IG03:
+       jmp      SHORT G_M55292_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M12462_IG04:
+G_M55292_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M12462_IG05:
+G_M55292_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M12462_IG06:
+G_M55292_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 19, prolog size 0, PerfScore 6.03, (MethodHash=d86dcf51) for method Silk.NET.Maths.Scalar:Min(short,short):short
+; Total bytes of code 19, prolog size 0, PerfScore 6.03, (MethodHash=7a272803) for method JITTest.ScalarShort:Min(short,short):short
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarShort:Max(short,short):short
@@ -7105,65 +7060,36 @@ G_M12462_IG06:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  rcx        
 ;  V01 arg1         [V01,T01] (  3,  3   )   short  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M6306_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M6306_IG02:
-       movsx    rcx, cx
-       movsx    rdx, dx
-       call     Silk.NET.Maths.Scalar:Max(short,short):short
-       nop      
-						;; bbWeight=1    PerfScore 1.75
-G_M6306_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 23, prolog size 4, PerfScore 5.55, (MethodHash=fcfbe75d) for method JITTest.ScalarShort:Max(short,short):short
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(short,short):short
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )   short  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T04] (  3,  2   )   short  ->  rdx         "Inline return value spill temp"
-;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
-;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;* V03 tmp1         [V03    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T04] (  3,  2   )   short  ->  rdx         "Inline return value spill temp"
+;  V05 cse0         [V05,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V06 cse1         [V06,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
-G_M2800_IG01:
+G_M6306_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M2800_IG02:
+G_M6306_IG02:
        movsx    rax, cx
        movsx    rdx, dx
        cmp      eax, edx
-       jge      SHORT G_M2800_IG04
+       jge      SHORT G_M6306_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M2800_IG03:
-       jmp      SHORT G_M2800_IG05
+G_M6306_IG03:
+       jmp      SHORT G_M6306_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M2800_IG04:
+G_M6306_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M2800_IG05:
+G_M6306_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M2800_IG06:
+G_M6306_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 19, prolog size 0, PerfScore 6.03, (MethodHash=175cf50f) for method Silk.NET.Maths.Scalar:Max(short,short):short
+; Total bytes of code 19, prolog size 0, PerfScore 6.03, (MethodHash=fcfbe75d) for method JITTest.ScalarShort:Max(short,short):short
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarShort:Larger(short,short):bool
@@ -7324,6 +7250,86 @@ G_M23835_IG03:
 ; Total bytes of code 42, prolog size 5, PerfScore 10.70, (MethodHash=0856a2e4) for method JITTest.ScalarShort:Clamp(short,short,short):short
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(short,short):short
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  rcx        
+;  V01 arg1         [V01,T01] (  3,  3   )   short  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V03 tmp1         [V03,T04] (  3,  2   )   short  ->  rdx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M2800_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M2800_IG02:
+       movsx    rax, cx
+       movsx    rdx, dx
+       cmp      eax, edx
+       jge      SHORT G_M2800_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M2800_IG03:
+       jmp      SHORT G_M2800_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M2800_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M2800_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M2800_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 19, prolog size 0, PerfScore 6.03, (MethodHash=175cf50f) for method Silk.NET.Maths.Scalar:Max(short,short):short
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(short,short):short
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  rcx        
+;  V01 arg1         [V01,T01] (  3,  3   )   short  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V03 tmp1         [V03,T04] (  3,  2   )   short  ->  rdx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  rdx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  rax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M12462_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M12462_IG02:
+       movsx    rax, cx
+       movsx    rdx, dx
+       cmp      eax, edx
+       jle      SHORT G_M12462_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M12462_IG03:
+       jmp      SHORT G_M12462_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M12462_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M12462_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M12462_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 19, prolog size 0, PerfScore 6.03, (MethodHash=d86dcf51) for method Silk.NET.Maths.Scalar:Min(short,short):short
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarShort:Negate(short):short
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
@@ -7332,51 +7338,23 @@ G_M23835_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  rcx        
-;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M59732_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M59732_IG02:
-       movsx    rcx, cx
-       call     Silk.NET.Maths.Scalar:Negate(short):short
-       nop      
-						;; bbWeight=1    PerfScore 1.50
-G_M59732_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 19, prolog size 4, PerfScore 4.90, (MethodHash=8d9016ab) for method JITTest.ScalarShort:Negate(short):short
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(short):short
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  rcx        
-;* V01 loc0         [V01    ] (  0,  0   )   short  ->  zero-ref    ld-addr-op
-;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V02 tmp1         [V02,T01] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M38726_IG01:
+G_M59732_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M38726_IG02:
+G_M59732_IG02:
        movsx    rax, cx
        neg      eax
        movsx    rax, ax
 						;; bbWeight=1    PerfScore 0.75
-G_M38726_IG03:
+G_M59732_IG03:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 11, prolog size 0, PerfScore 2.85, (MethodHash=517c68b9) for method Silk.NET.Maths.Scalar:Negate(short):short
+; Total bytes of code 11, prolog size 0, PerfScore 2.85, (MethodHash=8d9016ab) for method JITTest.ScalarShort:Negate(short):short
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarShort:Equal(short,short):bool
@@ -8560,7 +8538,7 @@ G_M7874_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )     int  ->  zero-ref   
 ;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V02 tmp1         [V02,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -8899,61 +8877,34 @@ G_M53713_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )     int  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M14664_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M14664_IG02:
-       call     Silk.NET.Maths.Scalar:Min(int,int):int
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M14664_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=236fc6b7) for method JITTest.ScalarUInt32:Min(int,int):int
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(int,int):int
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  rcx        
 ;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T02] (  3,  2   )     int  ->  rdx         "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )     int  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T02] (  3,  2   )     int  ->  rdx         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M22191_IG01:
+G_M14664_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M22191_IG02:
+G_M14664_IG02:
        cmp      ecx, edx
-       jbe      SHORT G_M22191_IG04
+       jbe      SHORT G_M14664_IG04
 						;; bbWeight=1    PerfScore 1.25
-G_M22191_IG03:
-       jmp      SHORT G_M22191_IG05
+G_M14664_IG03:
+       jmp      SHORT G_M14664_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M22191_IG04:
+G_M14664_IG04:
        mov      edx, ecx
 						;; bbWeight=0.50 PerfScore 0.12
-G_M22191_IG05:
+G_M14664_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M22191_IG06:
+G_M14664_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 11, prolog size 0, PerfScore 4.73, (MethodHash=1a40a950) for method Silk.NET.Maths.Scalar:Min(int,int):int
+; Total bytes of code 11, prolog size 0, PerfScore 4.73, (MethodHash=236fc6b7) for method JITTest.ScalarUInt32:Min(int,int):int
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUInt32:Max(int,int):int
@@ -8963,61 +8914,34 @@ G_M22191_IG06:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )     int  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M14102_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M14102_IG02:
-       call     Silk.NET.Maths.Scalar:Max(int,int):int
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M14102_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=7fd8c8e9) for method JITTest.ScalarUInt32:Max(int,int):int
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(int,int):int
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  rcx        
 ;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T02] (  3,  2   )     int  ->  rdx         "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )     int  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T02] (  3,  2   )     int  ->  rdx         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M5361_IG01:
+G_M14102_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M5361_IG02:
+G_M14102_IG02:
        cmp      ecx, edx
-       jae      SHORT G_M5361_IG04
+       jae      SHORT G_M14102_IG04
 						;; bbWeight=1    PerfScore 1.25
-G_M5361_IG03:
-       jmp      SHORT G_M5361_IG05
+G_M14102_IG03:
+       jmp      SHORT G_M14102_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M5361_IG04:
+G_M14102_IG04:
        mov      edx, ecx
 						;; bbWeight=0.50 PerfScore 0.12
-G_M5361_IG05:
+G_M14102_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M5361_IG06:
+G_M14102_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 11, prolog size 0, PerfScore 4.73, (MethodHash=223aeb0e) for method Silk.NET.Maths.Scalar:Max(int,int):int
+; Total bytes of code 11, prolog size 0, PerfScore 4.73, (MethodHash=7fd8c8e9) for method JITTest.ScalarUInt32:Max(int,int):int
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUInt32:Larger(int,int):bool
@@ -9168,6 +9092,78 @@ G_M59214_IG03:
 ; Total bytes of code 29, prolog size 5, PerfScore 8.90, (MethodHash=af4b18b1) for method JITTest.ScalarUInt32:Clamp(int,int,int):int
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(int,int):int
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  rcx        
+;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V03 tmp1         [V03,T02] (  3,  2   )     int  ->  rdx         "Inline return value spill temp"
+;
+; Lcl frame size = 0
+
+G_M5361_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M5361_IG02:
+       cmp      ecx, edx
+       jae      SHORT G_M5361_IG04
+						;; bbWeight=1    PerfScore 1.25
+G_M5361_IG03:
+       jmp      SHORT G_M5361_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M5361_IG04:
+       mov      edx, ecx
+						;; bbWeight=0.50 PerfScore 0.12
+G_M5361_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M5361_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 11, prolog size 0, PerfScore 4.73, (MethodHash=223aeb0e) for method Silk.NET.Maths.Scalar:Max(int,int):int
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(int,int):int
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  rcx        
+;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V03 tmp1         [V03,T02] (  3,  2   )     int  ->  rdx         "Inline return value spill temp"
+;
+; Lcl frame size = 0
+
+G_M22191_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M22191_IG02:
+       cmp      ecx, edx
+       jbe      SHORT G_M22191_IG04
+						;; bbWeight=1    PerfScore 1.25
+G_M22191_IG03:
+       jmp      SHORT G_M22191_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M22191_IG04:
+       mov      edx, ecx
+						;; bbWeight=0.50 PerfScore 0.12
+G_M22191_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M22191_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 11, prolog size 0, PerfScore 4.73, (MethodHash=1a40a950) for method Silk.NET.Maths.Scalar:Min(int,int):int
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarUInt32:Negate(int):int
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
@@ -9175,8 +9171,10 @@ G_M59214_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  rcx        
+;* V00 arg0         [V00    ] (  0,  0   )     int  ->  zero-ref   
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
+;* V02 tmp1         [V02    ] (  0,  0   )     int  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp2         [V03    ] (  0,  0   )     int  ->  zero-ref    ld-addr-op "Inline ldloca(s) first use temp"
 ;
 ; Lcl frame size = 40
 
@@ -9184,39 +9182,11 @@ G_M16865_IG01:
        sub      rsp, 40
 						;; bbWeight=1    PerfScore 0.25
 G_M16865_IG02:
-       call     Silk.NET.Maths.Scalar:Negate(int):int
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M16865_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=9890be1e) for method JITTest.ScalarUInt32:Negate(int):int
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(int):int
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;* V00 arg0         [V00    ] (  0,  0   )     int  ->  zero-ref   
-;* V01 loc0         [V01    ] (  0,  0   )     int  ->  zero-ref    ld-addr-op
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M7398_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M7398_IG02:
        call     Silk.NET.Maths.Scalar:ThrowInvalidType()
        int3     
 						;; bbWeight=0    PerfScore 0.00
 
-; Total bytes of code 10, prolog size 4, PerfScore 1.25, (MethodHash=4620e319) for method Silk.NET.Maths.Scalar:Negate(int):int
+; Total bytes of code 10, prolog size 4, PerfScore 1.25, (MethodHash=9890be1e) for method JITTest.ScalarUInt32:Negate(int):int
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUInt32:Equal(int,int):bool
@@ -10388,7 +10358,7 @@ G_M44407_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )     int  ->  zero-ref   
 ;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V02 tmp1         [V02,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -10725,61 +10695,34 @@ G_M45924_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )     int  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M18973_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M18973_IG02:
-       call     Silk.NET.Maths.Scalar:Min(int,int):int
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M18973_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=0d39b5e2) for method JITTest.ScalarInt32:Min(int,int):int
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(int,int):int
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  rcx        
 ;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T02] (  3,  2   )     int  ->  rdx         "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )     int  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T02] (  3,  2   )     int  ->  rdx         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M22191_IG01:
+G_M18973_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M22191_IG02:
+G_M18973_IG02:
        cmp      ecx, edx
-       jle      SHORT G_M22191_IG04
+       jle      SHORT G_M18973_IG04
 						;; bbWeight=1    PerfScore 1.25
-G_M22191_IG03:
-       jmp      SHORT G_M22191_IG05
+G_M18973_IG03:
+       jmp      SHORT G_M18973_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M22191_IG04:
+G_M18973_IG04:
        mov      edx, ecx
 						;; bbWeight=0.50 PerfScore 0.12
-G_M22191_IG05:
+G_M18973_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M22191_IG06:
+G_M18973_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 11, prolog size 0, PerfScore 4.73, (MethodHash=1a40a950) for method Silk.NET.Maths.Scalar:Min(int,int):int
+; Total bytes of code 11, prolog size 0, PerfScore 4.73, (MethodHash=0d39b5e2) for method JITTest.ScalarInt32:Min(int,int):int
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarInt32:Max(int,int):int
@@ -10789,61 +10732,34 @@ G_M22191_IG06:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )     int  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M35779_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M35779_IG02:
-       call     Silk.NET.Maths.Scalar:Max(int,int):int
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M35779_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=428a743c) for method JITTest.ScalarInt32:Max(int,int):int
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(int,int):int
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  rcx        
 ;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T02] (  3,  2   )     int  ->  rdx         "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )     int  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T02] (  3,  2   )     int  ->  rdx         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M5361_IG01:
+G_M35779_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M5361_IG02:
+G_M35779_IG02:
        cmp      ecx, edx
-       jge      SHORT G_M5361_IG04
+       jge      SHORT G_M35779_IG04
 						;; bbWeight=1    PerfScore 1.25
-G_M5361_IG03:
-       jmp      SHORT G_M5361_IG05
+G_M35779_IG03:
+       jmp      SHORT G_M35779_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M5361_IG04:
+G_M35779_IG04:
        mov      edx, ecx
 						;; bbWeight=0.50 PerfScore 0.12
-G_M5361_IG05:
+G_M35779_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M5361_IG06:
+G_M35779_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 11, prolog size 0, PerfScore 4.73, (MethodHash=223aeb0e) for method Silk.NET.Maths.Scalar:Max(int,int):int
+; Total bytes of code 11, prolog size 0, PerfScore 4.73, (MethodHash=428a743c) for method JITTest.ScalarInt32:Max(int,int):int
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarInt32:Larger(int,int):bool
@@ -10994,6 +10910,78 @@ G_M27291_IG03:
 ; Total bytes of code 29, prolog size 5, PerfScore 8.90, (MethodHash=1ffd9564) for method JITTest.ScalarInt32:Clamp(int,int,int):int
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(int,int):int
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  rcx        
+;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V03 tmp1         [V03,T02] (  3,  2   )     int  ->  rdx         "Inline return value spill temp"
+;
+; Lcl frame size = 0
+
+G_M5361_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M5361_IG02:
+       cmp      ecx, edx
+       jge      SHORT G_M5361_IG04
+						;; bbWeight=1    PerfScore 1.25
+G_M5361_IG03:
+       jmp      SHORT G_M5361_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M5361_IG04:
+       mov      edx, ecx
+						;; bbWeight=0.50 PerfScore 0.12
+G_M5361_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M5361_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 11, prolog size 0, PerfScore 4.73, (MethodHash=223aeb0e) for method Silk.NET.Maths.Scalar:Max(int,int):int
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(int,int):int
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  rcx        
+;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V03 tmp1         [V03,T02] (  3,  2   )     int  ->  rdx         "Inline return value spill temp"
+;
+; Lcl frame size = 0
+
+G_M22191_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M22191_IG02:
+       cmp      ecx, edx
+       jle      SHORT G_M22191_IG04
+						;; bbWeight=1    PerfScore 1.25
+G_M22191_IG03:
+       jmp      SHORT G_M22191_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M22191_IG04:
+       mov      edx, ecx
+						;; bbWeight=0.50 PerfScore 0.12
+G_M22191_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M22191_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 11, prolog size 0, PerfScore 4.73, (MethodHash=1a40a950) for method Silk.NET.Maths.Scalar:Min(int,int):int
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarInt32:Negate(int):int
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
@@ -11002,49 +10990,22 @@ G_M27291_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  rcx        
-;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M44628_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M44628_IG02:
-       call     Silk.NET.Maths.Scalar:Negate(int):int
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M44628_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=605651ab) for method JITTest.ScalarInt32:Negate(int):int
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(int):int
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  rcx        
-;* V01 loc0         [V01    ] (  0,  0   )     int  ->  zero-ref    ld-addr-op
-;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V02 tmp1         [V02,T01] (  2,  2   )     int  ->  rax         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M7398_IG01:
+G_M44628_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M7398_IG02:
+G_M44628_IG02:
        mov      eax, ecx
        neg      eax
 						;; bbWeight=1    PerfScore 0.50
-G_M7398_IG03:
+G_M44628_IG03:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 5, prolog size 0, PerfScore 2.00, (MethodHash=4620e319) for method Silk.NET.Maths.Scalar:Negate(int):int
+; Total bytes of code 5, prolog size 0, PerfScore 2.00, (MethodHash=605651ab) for method JITTest.ScalarInt32:Negate(int):int
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarInt32:Equal(int,int):bool
@@ -12226,7 +12187,7 @@ G_M54136_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )    long  ->  zero-ref   
 ;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V02 tmp1         [V02,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -12584,62 +12545,35 @@ G_M39755_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )    long  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )    long  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M65298_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M65298_IG02:
-       call     Silk.NET.Maths.Scalar:Min(long,long):long
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M65298_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=accc00ed) for method JITTest.ScalarUInt64:Min(long,long):long
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(long,long):long
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00,T00] (  4,  3.50)    long  ->  rcx        
 ;  V01 arg1         [V01,T01] (  4,  3.50)    long  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 tmp2         [V04,T02] (  3,  2   )    long  ->  rdx         "Inline return value spill temp"
+;* V04 tmp2         [V04    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V05 tmp3         [V05,T02] (  3,  2   )    long  ->  rdx         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M34166_IG01:
+G_M65298_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M34166_IG02:
+G_M65298_IG02:
        cmp      rcx, rdx
-       jbe      SHORT G_M34166_IG04
+       jbe      SHORT G_M65298_IG04
 						;; bbWeight=1    PerfScore 1.25
-G_M34166_IG03:
-       jmp      SHORT G_M34166_IG05
+G_M65298_IG03:
+       jmp      SHORT G_M65298_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M34166_IG04:
+G_M65298_IG04:
        mov      rdx, rcx
 						;; bbWeight=0.50 PerfScore 0.12
-G_M34166_IG05:
+G_M65298_IG05:
        mov      rax, rdx
 						;; bbWeight=1    PerfScore 0.25
-G_M34166_IG06:
+G_M65298_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 14, prolog size 0, PerfScore 5.03, (MethodHash=02627a89) for method Silk.NET.Maths.Scalar:Min(long,long):long
+; Total bytes of code 14, prolog size 0, PerfScore 5.03, (MethodHash=accc00ed) for method JITTest.ScalarUInt64:Min(long,long):long
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUInt64:Max(long,long):long
@@ -12649,62 +12583,35 @@ G_M34166_IG06:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )    long  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )    long  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M36620_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M36620_IG02:
-       call     Silk.NET.Maths.Scalar:Max(long,long):long
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M36620_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=a97970f3) for method JITTest.ScalarUInt64:Max(long,long):long
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(long,long):long
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00,T00] (  4,  3.50)    long  ->  rcx        
 ;  V01 arg1         [V01,T01] (  4,  3.50)    long  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 tmp2         [V04,T02] (  3,  2   )    long  ->  rdx         "Inline return value spill temp"
+;* V04 tmp2         [V04    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V05 tmp3         [V05,T02] (  3,  2   )    long  ->  rdx         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M54120_IG01:
+G_M36620_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M54120_IG02:
+G_M36620_IG02:
        cmp      rcx, rdx
-       jae      SHORT G_M54120_IG04
+       jae      SHORT G_M36620_IG04
 						;; bbWeight=1    PerfScore 1.25
-G_M54120_IG03:
-       jmp      SHORT G_M54120_IG05
+G_M36620_IG03:
+       jmp      SHORT G_M36620_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M54120_IG04:
+G_M36620_IG04:
        mov      rdx, rcx
 						;; bbWeight=0.50 PerfScore 0.12
-G_M54120_IG05:
+G_M36620_IG05:
        mov      rax, rdx
 						;; bbWeight=1    PerfScore 0.25
-G_M54120_IG06:
+G_M36620_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 14, prolog size 0, PerfScore 5.03, (MethodHash=79ab2c97) for method Silk.NET.Maths.Scalar:Max(long,long):long
+; Total bytes of code 14, prolog size 0, PerfScore 5.03, (MethodHash=a97970f3) for method JITTest.ScalarUInt64:Max(long,long):long
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUInt64:Larger(long,long):bool
@@ -12859,6 +12766,80 @@ G_M21965_IG03:
 ; Total bytes of code 31, prolog size 5, PerfScore 9.10, (MethodHash=8145aa32) for method JITTest.ScalarUInt64:Clamp(long,long,long):long
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(long,long):long
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  4,  3.50)    long  ->  rcx        
+;  V01 arg1         [V01,T01] (  4,  3.50)    long  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T02] (  3,  2   )    long  ->  rdx         "Inline return value spill temp"
+;
+; Lcl frame size = 0
+
+G_M54120_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M54120_IG02:
+       cmp      rcx, rdx
+       jae      SHORT G_M54120_IG04
+						;; bbWeight=1    PerfScore 1.25
+G_M54120_IG03:
+       jmp      SHORT G_M54120_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M54120_IG04:
+       mov      rdx, rcx
+						;; bbWeight=0.50 PerfScore 0.12
+G_M54120_IG05:
+       mov      rax, rdx
+						;; bbWeight=1    PerfScore 0.25
+G_M54120_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 14, prolog size 0, PerfScore 5.03, (MethodHash=79ab2c97) for method Silk.NET.Maths.Scalar:Max(long,long):long
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(long,long):long
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  4,  3.50)    long  ->  rcx        
+;  V01 arg1         [V01,T01] (  4,  3.50)    long  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T02] (  3,  2   )    long  ->  rdx         "Inline return value spill temp"
+;
+; Lcl frame size = 0
+
+G_M34166_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M34166_IG02:
+       cmp      rcx, rdx
+       jbe      SHORT G_M34166_IG04
+						;; bbWeight=1    PerfScore 1.25
+G_M34166_IG03:
+       jmp      SHORT G_M34166_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M34166_IG04:
+       mov      rdx, rcx
+						;; bbWeight=0.50 PerfScore 0.12
+G_M34166_IG05:
+       mov      rax, rdx
+						;; bbWeight=1    PerfScore 0.25
+G_M34166_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 14, prolog size 0, PerfScore 5.03, (MethodHash=02627a89) for method Silk.NET.Maths.Scalar:Min(long,long):long
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarUInt64:Negate(long):long
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
@@ -12866,8 +12847,10 @@ G_M21965_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )    long  ->  rcx        
+;* V00 arg0         [V00    ] (  0,  0   )    long  ->  zero-ref   
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
+;* V02 tmp1         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp2         [V03    ] (  0,  0   )    long  ->  zero-ref    ld-addr-op "Inline ldloca(s) first use temp"
 ;
 ; Lcl frame size = 40
 
@@ -12875,39 +12858,11 @@ G_M34306_IG01:
        sub      rsp, 40
 						;; bbWeight=1    PerfScore 0.25
 G_M34306_IG02:
-       call     Silk.NET.Maths.Scalar:Negate(long):long
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M34306_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=120179fd) for method JITTest.ScalarUInt64:Negate(long):long
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(long):long
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;* V00 arg0         [V00    ] (  0,  0   )    long  ->  zero-ref   
-;* V01 loc0         [V01    ] (  0,  0   )    long  ->  zero-ref    ld-addr-op
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M39782_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M39782_IG02:
        call     Silk.NET.Maths.Scalar:ThrowInvalidType()
        int3     
 						;; bbWeight=0    PerfScore 0.00
 
-; Total bytes of code 10, prolog size 4, PerfScore 1.25, (MethodHash=f3226499) for method Silk.NET.Maths.Scalar:Negate(long):long
+; Total bytes of code 10, prolog size 4, PerfScore 1.25, (MethodHash=120179fd) for method JITTest.ScalarUInt64:Negate(long):long
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUInt64:Equal(long,long):bool
@@ -14082,7 +14037,7 @@ G_M53741_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )    long  ->  zero-ref   
 ;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V02 tmp1         [V02,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -14426,62 +14381,35 @@ G_M49182_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )    long  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )    long  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M21159_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M21159_IG02:
-       call     Silk.NET.Maths.Scalar:Min(long,long):long
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M21159_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=7956ad58) for method JITTest.ScalarInt64:Min(long,long):long
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(long,long):long
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00,T00] (  4,  3.50)    long  ->  rcx        
 ;  V01 arg1         [V01,T01] (  4,  3.50)    long  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 tmp2         [V04,T02] (  3,  2   )    long  ->  rdx         "Inline return value spill temp"
+;* V04 tmp2         [V04    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V05 tmp3         [V05,T02] (  3,  2   )    long  ->  rdx         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M34166_IG01:
+G_M21159_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M34166_IG02:
+G_M21159_IG02:
        cmp      rcx, rdx
-       jle      SHORT G_M34166_IG04
+       jle      SHORT G_M21159_IG04
 						;; bbWeight=1    PerfScore 1.25
-G_M34166_IG03:
-       jmp      SHORT G_M34166_IG05
+G_M21159_IG03:
+       jmp      SHORT G_M21159_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M34166_IG04:
+G_M21159_IG04:
        mov      rdx, rcx
 						;; bbWeight=0.50 PerfScore 0.12
-G_M34166_IG05:
+G_M21159_IG05:
        mov      rax, rdx
 						;; bbWeight=1    PerfScore 0.25
-G_M34166_IG06:
+G_M21159_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 14, prolog size 0, PerfScore 5.03, (MethodHash=02627a89) for method Silk.NET.Maths.Scalar:Min(long,long):long
+; Total bytes of code 14, prolog size 0, PerfScore 5.03, (MethodHash=7956ad58) for method JITTest.ScalarInt64:Min(long,long):long
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarInt64:Max(long,long):long
@@ -14491,62 +14419,35 @@ G_M34166_IG06:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )    long  ->  rcx        
-;  V01 arg1         [V01,T01] (  3,  3   )    long  ->  rdx        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M33465_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M33465_IG02:
-       call     Silk.NET.Maths.Scalar:Max(long,long):long
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M33465_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=ae9f7d46) for method JITTest.ScalarInt64:Max(long,long):long
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(long,long):long
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00,T00] (  4,  3.50)    long  ->  rcx        
 ;  V01 arg1         [V01,T01] (  4,  3.50)    long  ->  rdx        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 tmp2         [V04,T02] (  3,  2   )    long  ->  rdx         "Inline return value spill temp"
+;* V04 tmp2         [V04    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V05 tmp3         [V05,T02] (  3,  2   )    long  ->  rdx         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M54120_IG01:
+G_M33465_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M54120_IG02:
+G_M33465_IG02:
        cmp      rcx, rdx
-       jge      SHORT G_M54120_IG04
+       jge      SHORT G_M33465_IG04
 						;; bbWeight=1    PerfScore 1.25
-G_M54120_IG03:
-       jmp      SHORT G_M54120_IG05
+G_M33465_IG03:
+       jmp      SHORT G_M33465_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M54120_IG04:
+G_M33465_IG04:
        mov      rdx, rcx
 						;; bbWeight=0.50 PerfScore 0.12
-G_M54120_IG05:
+G_M33465_IG05:
        mov      rax, rdx
 						;; bbWeight=1    PerfScore 0.25
-G_M54120_IG06:
+G_M33465_IG06:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 14, prolog size 0, PerfScore 5.03, (MethodHash=79ab2c97) for method Silk.NET.Maths.Scalar:Max(long,long):long
+; Total bytes of code 14, prolog size 0, PerfScore 5.03, (MethodHash=ae9f7d46) for method JITTest.ScalarInt64:Max(long,long):long
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarInt64:Larger(long,long):bool
@@ -14701,6 +14602,80 @@ G_M29080_IG03:
 ; Total bytes of code 31, prolog size 5, PerfScore 9.10, (MethodHash=1b498e67) for method JITTest.ScalarInt64:Clamp(long,long,long):long
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(long,long):long
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  4,  3.50)    long  ->  rcx        
+;  V01 arg1         [V01,T01] (  4,  3.50)    long  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T02] (  3,  2   )    long  ->  rdx         "Inline return value spill temp"
+;
+; Lcl frame size = 0
+
+G_M54120_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M54120_IG02:
+       cmp      rcx, rdx
+       jge      SHORT G_M54120_IG04
+						;; bbWeight=1    PerfScore 1.25
+G_M54120_IG03:
+       jmp      SHORT G_M54120_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M54120_IG04:
+       mov      rdx, rcx
+						;; bbWeight=0.50 PerfScore 0.12
+G_M54120_IG05:
+       mov      rax, rdx
+						;; bbWeight=1    PerfScore 0.25
+G_M54120_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 14, prolog size 0, PerfScore 5.03, (MethodHash=79ab2c97) for method Silk.NET.Maths.Scalar:Max(long,long):long
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(long,long):long
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  4,  3.50)    long  ->  rcx        
+;  V01 arg1         [V01,T01] (  4,  3.50)    long  ->  rdx        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T02] (  3,  2   )    long  ->  rdx         "Inline return value spill temp"
+;
+; Lcl frame size = 0
+
+G_M34166_IG01:
+						;; bbWeight=1    PerfScore 0.00
+G_M34166_IG02:
+       cmp      rcx, rdx
+       jle      SHORT G_M34166_IG04
+						;; bbWeight=1    PerfScore 1.25
+G_M34166_IG03:
+       jmp      SHORT G_M34166_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M34166_IG04:
+       mov      rdx, rcx
+						;; bbWeight=0.50 PerfScore 0.12
+G_M34166_IG05:
+       mov      rax, rdx
+						;; bbWeight=1    PerfScore 0.25
+G_M34166_IG06:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 14, prolog size 0, PerfScore 5.03, (MethodHash=02627a89) for method Silk.NET.Maths.Scalar:Min(long,long):long
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarInt64:Negate(long):long
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
@@ -14709,49 +14684,22 @@ G_M29080_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )    long  ->  rcx        
-;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M60599_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M60599_IG02:
-       call     Silk.NET.Maths.Scalar:Negate(long):long
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M60599_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=3ce51348) for method JITTest.ScalarInt64:Negate(long):long
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(long):long
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )    long  ->  rcx        
-;* V01 loc0         [V01    ] (  0,  0   )    long  ->  zero-ref    ld-addr-op
-;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V02 tmp1         [V02,T01] (  2,  2   )    long  ->  rax         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M39782_IG01:
+G_M60599_IG01:
 						;; bbWeight=1    PerfScore 0.00
-G_M39782_IG02:
+G_M60599_IG02:
        mov      rax, rcx
        neg      rax
 						;; bbWeight=1    PerfScore 0.50
-G_M39782_IG03:
+G_M60599_IG03:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 7, prolog size 0, PerfScore 2.20, (MethodHash=f3226499) for method Silk.NET.Maths.Scalar:Negate(long):long
+; Total bytes of code 7, prolog size 0, PerfScore 2.20, (MethodHash=3ce51348) for method JITTest.ScalarInt64:Negate(long):long
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarInt64:Equal(long,long):bool
@@ -15880,11 +15828,12 @@ G_M49115_IG166:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V02 tmp1         [V02,T01] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V03 tmp2         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V05 tmp4         [V05,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V06 rat0         [V06,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V06 tmp5         [V06,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V07 rat0         [V07,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
 ;
 ; Lcl frame size = 40
 
@@ -15916,7 +15865,7 @@ G_M27459_IG03:
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;* V01 arg1         [V01    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T04] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;  V06 tmp4         [V06,T07] (  2,  4   )   float  ->  mm6         "non-inline candidate call"
@@ -15924,9 +15873,10 @@ G_M27459_IG03:
 ;  V08 tmp6         [V08,T00] (  4,  6.50)     ref  ->  rdi         "inline UNBOX clone1"
 ;  V09 tmp7         [V09,T02] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
 ;  V10 tmp8         [V10,T03] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
-;  V11 tmp9         [V11,T05] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T06] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
-;  V13 rat0         [V13,T08] (  2,  4   )   float  ->  mm0         "argument with side effect"
+;  V11 tmp9         [V11,T04] (  2,  2   )  ushort  ->  rax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T05] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T06] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V14 rat0         [V14,T08] (  2,  4   )   float  ->  mm0         "argument with side effect"
 ;
 ; Lcl frame size = 56
 
@@ -15960,7 +15910,7 @@ G_M56341_IG03:
        call     CORINFO_HELP_UNBOX
 						;; bbWeight=0.25 PerfScore 0.38
 G_M56341_IG04:
-       movsx    rax, word  ptr [rdi+8]
+       movzx    rax, word  ptr [rdi+8]
 						;; bbWeight=1    PerfScore 2.00
 G_M56341_IG05:
        vmovaps  xmm6, qword ptr [rsp+20H]
@@ -15970,7 +15920,7 @@ G_M56341_IG05:
        ret      
 						;; bbWeight=1    PerfScore 6.25
 
-; Total bytes of code 121, prolog size 15, PerfScore 37.08, (MethodHash=2ef123ea) for method JITTest.ScalarHalf:Atan2(System.Half,System.Half):System.Half
+; Total bytes of code 120, prolog size 15, PerfScore 36.98, (MethodHash=2ef123ea) for method JITTest.ScalarHalf:Atan2(System.Half,System.Half):System.Half
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarHalf:Cos(System.Half):System.Half
@@ -15982,11 +15932,12 @@ G_M56341_IG05:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V02 tmp1         [V02,T01] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V03 tmp2         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V05 tmp4         [V05,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V06 rat0         [V06,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V06 tmp5         [V06,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V07 rat0         [V07,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
 ;
 ; Lcl frame size = 40
 
@@ -16017,11 +15968,12 @@ G_M22342_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V02 tmp1         [V02,T01] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V03 tmp2         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V05 tmp4         [V05,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V06 rat0         [V06,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V06 tmp5         [V06,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V07 rat0         [V07,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
 ;
 ; Lcl frame size = 40
 
@@ -16051,8 +16003,10 @@ G_M23790_IG03:
 ; Final local variable assignments
 ;
 ;  V00 OutArgs      [V00    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;* V01 tmp1         [V01    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
-;  V02 tmp2         [V02,T00] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;* V02 tmp2         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;  V03 tmp3         [V03,T00] (  2,  2   )  ushort  ->  rax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V04 tmp4         [V04,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 40
 
@@ -16083,8 +16037,10 @@ RWD00  dd	3F800000h
 ; Final local variable assignments
 ;
 ;  V00 OutArgs      [V00    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;* V01 tmp1         [V01    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
-;  V02 tmp2         [V02,T00] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;* V02 tmp2         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;  V03 tmp3         [V03,T00] (  2,  2   )  ushort  ->  rax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V04 tmp4         [V04,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 40
 
@@ -16166,7 +16122,8 @@ G_M63798_IG06:
 ; Final local variable assignments
 ;
 ;  V00 OutArgs      [V00    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V01 tmp1         [V01,T00] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;  V02 tmp2         [V02,T00] (  2,  2   )  ushort  ->  rax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 40
 
@@ -16198,7 +16155,8 @@ RWD08  dq	400921FB54442D18h
 ; Final local variable assignments
 ;
 ;  V00 OutArgs      [V00    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V01 tmp1         [V01,T00] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;  V02 tmp2         [V02,T00] (  2,  2   )  ushort  ->  rax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 40
 
@@ -16230,7 +16188,8 @@ RWD08  dq	401921FB54442D18h
 ; Final local variable assignments
 ;
 ;  V00 OutArgs      [V00    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V01 tmp1         [V01,T00] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;  V02 tmp2         [V02,T00] (  2,  2   )  ushort  ->  rax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 40
 
@@ -16262,9 +16221,10 @@ RWD08  dq	3FF921FB54442D18h
 ; Final local variable assignments
 ;
 ;# V00 OutArgs      [V00    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V01 tmp1         [V01    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V02 tmp2         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "NewObj constructor temp"
-;* V03 tmp3         [V03    ] (  0,  0   )  ushort  ->  zero-ref    V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V03 tmp3         [V03,T00] (  2,  2   )  ushort  ->  rax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V04 tmp4         [V04,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 0
 
@@ -16288,16 +16248,17 @@ G_M41528_IG03:
 ; Final local variable assignments
 ;
 ;# V00 OutArgs      [V00    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
-;* V01 tmp1         [V01    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V02 tmp2         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "NewObj constructor temp"
-;* V03 tmp3         [V03    ] (  0,  0   )  ushort  ->  zero-ref    V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V03 tmp3         [V03,T00] (  2,  2   )  ushort  ->  rax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V04 tmp4         [V04,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 0
 
 G_M35184_IG01:
 						;; bbWeight=1    PerfScore 0.00
 G_M35184_IG02:
-       mov      eax, -0x400
+       mov      eax, 0xFC00
 						;; bbWeight=1    PerfScore 0.25
 G_M35184_IG03:
        ret      
@@ -16313,10 +16274,12 @@ G_M35184_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T01] (  3,  3   )  double  ->  mm0        
+;  V00 arg0         [V00,T02] (  3,  3   )  double  ->  mm0        
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;* V02 tmp1         [V02    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
-;  V03 tmp2         [V03,T00] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;* V03 tmp2         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  rax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 40
 
@@ -16345,13 +16308,15 @@ G_M25398_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;* V02 tmp1         [V02    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V03 tmp2         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V04 tmp3         [V04,T01] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V04 tmp3         [V04    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V05 tmp4         [V05    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;  V06 tmp5         [V06,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V07 tmp6         [V07,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V08 tmp7         [V08,T03] (  2,  2   )  ushort  ->  rcx         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V07 tmp6         [V07,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V08 tmp7         [V08,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V09 tmp8         [V09,T03] (  2,  2   )  ushort  ->  rax         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V10 tmp9         [V10,T04] (  2,  2   )  ushort  ->  rcx         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 40
 
@@ -16383,19 +16348,21 @@ G_M39678_IG03:
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;* V01 arg1         [V01    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;* V03 tmp1         [V03    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V06 tmp4         [V06,T02] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V08 tmp6         [V08    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V09 tmp7         [V09,T07] (  2,  4   )   float  ->  mm6         "non-inline candidate call"
+;  V09 tmp7         [V09,T08] (  2,  4   )   float  ->  mm6         "non-inline candidate call"
 ;  V10 tmp8         [V10,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
 ;  V11 tmp9         [V11,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T05] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
-;  V15 tmp13        [V15,T06] (  2,  2   )  ushort  ->  rsi         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T02] (  2,  2   )  ushort  ->  rax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T05] (  2,  2   )  ushort  ->  rax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T06] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V17 tmp15        [V17,T07] (  2,  2   )  ushort  ->  rsi         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 48
 
@@ -16435,21 +16402,23 @@ G_M42172_IG03:
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;* V01 arg1         [V01    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;* V03 tmp1         [V03    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V06 tmp4         [V06,T02] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V08 tmp6         [V08    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V09 tmp7         [V09,T07] (  2,  4   )   float  ->  mm6         "non-inline candidate call"
+;  V09 tmp7         [V09,T08] (  2,  4   )   float  ->  mm6         "non-inline candidate call"
 ;  V10 tmp8         [V10,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
 ;  V11 tmp9         [V11,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T05] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
-;  V15 tmp13        [V15,T06] (  2,  2   )  ushort  ->  rsi         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
-;  V16 tmp14        [V16,T08] (  2,  4   )   float  ->  mm0         "argument with side effect"
-;  V17 tmp15        [V17,T09] (  2,  4   )   float  ->  mm0         "argument with side effect"
+;  V12 tmp10        [V12,T02] (  2,  2   )  ushort  ->  rax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T05] (  2,  2   )  ushort  ->  rax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T06] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V17 tmp15        [V17,T07] (  2,  2   )  ushort  ->  rsi         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
+;  V18 tmp16        [V18,T09] (  2,  4   )   float  ->  mm0         "argument with side effect"
+;  V19 tmp17        [V19,T10] (  2,  4   )   float  ->  mm0         "argument with side effect"
 ;
 ; Lcl frame size = 48
 
@@ -16491,19 +16460,21 @@ G_M18555_IG03:
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;* V01 arg1         [V01    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;* V03 tmp1         [V03    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V06 tmp4         [V06,T02] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V08 tmp6         [V08    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V09 tmp7         [V09,T07] (  2,  4   )   float  ->  mm6         "non-inline candidate call"
+;  V09 tmp7         [V09,T08] (  2,  4   )   float  ->  mm6         "non-inline candidate call"
 ;  V10 tmp8         [V10,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
 ;  V11 tmp9         [V11,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T05] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
-;  V15 tmp13        [V15,T06] (  2,  2   )  ushort  ->  rsi         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T02] (  2,  2   )  ushort  ->  rax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T05] (  2,  2   )  ushort  ->  rax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T06] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V17 tmp15        [V17,T07] (  2,  2   )  ushort  ->  rsi         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 48
 
@@ -16543,19 +16514,21 @@ G_M13193_IG03:
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;* V01 arg1         [V01    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;* V03 tmp1         [V03    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V06 tmp4         [V06,T02] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V08 tmp6         [V08    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V09 tmp7         [V09,T07] (  2,  4   )   float  ->  mm6         "non-inline candidate call"
+;  V09 tmp7         [V09,T08] (  2,  4   )   float  ->  mm6         "non-inline candidate call"
 ;  V10 tmp8         [V10,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
 ;  V11 tmp9         [V11,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T05] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
-;  V15 tmp13        [V15,T06] (  2,  2   )  ushort  ->  rsi         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T02] (  2,  2   )  ushort  ->  rax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T05] (  2,  2   )  ushort  ->  rax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T06] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V17 tmp15        [V17,T07] (  2,  2   )  ushort  ->  rsi         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 48
 
@@ -16595,19 +16568,21 @@ G_M16593_IG03:
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;* V01 arg1         [V01    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;* V03 tmp1         [V03    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V06 tmp4         [V06,T02] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V08 tmp6         [V08    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V09 tmp7         [V09,T07] (  2,  4   )   float  ->  mm6         "non-inline candidate call"
+;  V09 tmp7         [V09,T08] (  2,  4   )   float  ->  mm6         "non-inline candidate call"
 ;  V10 tmp8         [V10,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
 ;  V11 tmp9         [V11,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T05] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
-;  V15 tmp13        [V15,T06] (  2,  2   )  ushort  ->  rsi         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T02] (  2,  2   )  ushort  ->  rax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T05] (  2,  2   )  ushort  ->  rax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T06] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V17 tmp15        [V17,T07] (  2,  2   )  ushort  ->  rsi         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 48
 
@@ -16647,105 +16622,82 @@ G_M26926_IG03:
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;* V01 arg1         [V01    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V04 tmp2         [V04,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
-;
-; Lcl frame size = 40
-
-G_M33079_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M33079_IG02:
-       call     Silk.NET.Maths.Scalar:Min(System.Half,System.Half):System.Half
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M33079_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=319e7ec8) for method JITTest.ScalarHalf:Min(System.Half,System.Half):System.Half
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(System.Half,System.Half):System.Half
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
-;* V01 arg1         [V01    ] (  0,  0   )  struct ( 8) zero-ref   
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T02] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V06 tmp4         [V06,T06] (  8,  8   )   float  ->  mm6         "non-inline candidate call"
-;  V07 tmp5         [V07,T08] (  5,  3   )   float  ->  mm0         "Inline return value spill temp"
-;  V08 tmp6         [V08,T07] (  5,  6.50)   float  ->  mm0         "Inlining Arg"
-;  V09 tmp7         [V09,T05] (  2,  0.50)     int  ->  rax         "Inline return value spill temp"
-;* V10 tmp8         [V10    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
-;  V11 tmp9         [V11,T09] (  2,  0.50)  simd16  ->  mm1         "Inline stloc first use temp"
-;  V12 tmp10        [V12,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V15 tmp13        [V15,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
+;* V08 tmp6         [V08    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
+;  V09 tmp7         [V09,T09] (  8,  8   )   float  ->  mm6         "non-inline candidate call"
+;  V10 tmp8         [V10,T11] (  5,  3   )   float  ->  mm0         "Inline return value spill temp"
+;  V11 tmp9         [V11,T10] (  5,  6.50)   float  ->  mm0         "Inlining Arg"
+;  V12 tmp10        [V12,T08] (  2,  0.50)     int  ->  rax         "Inline return value spill temp"
+;* V13 tmp11        [V13    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V14 tmp12        [V14,T12] (  2,  0.50)  simd16  ->  mm1         "Inline stloc first use temp"
+;  V15 tmp13        [V15,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V17 tmp15        [V17,T02] (  2,  2   )  ushort  ->  rax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V18 tmp16        [V18,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V19 tmp17        [V19,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V20 tmp18        [V20,T05] (  2,  2   )  ushort  ->  rax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V21 tmp19        [V21,T06] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V22 tmp20        [V22,T07] (  2,  2   )  ushort  ->  rsi         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 48
 
-G_M54452_IG01:
+G_M33079_IG01:
        push     rsi
        sub      rsp, 48
        vzeroupper 
        vmovaps  qword ptr [rsp+20H], xmm6
 						;; bbWeight=1    PerfScore 5.25
-G_M54452_IG02:
+G_M33079_IG02:
        movzx    rsi, dx
        call     System.Half:op_Explicit(System.Half):float
        vmovaps  xmm6, xmm0
        mov      ecx, esi
        call     System.Half:op_Explicit(System.Half):float
        vucomiss xmm6, xmm0
-       jp       SHORT G_M54452_IG03
-       je       SHORT G_M54452_IG06
+       jp       SHORT G_M33079_IG03
+       je       SHORT G_M33079_IG06
 						;; bbWeight=1    PerfScore 5.75
-G_M54452_IG03:
+G_M33079_IG03:
        vucomiss xmm6, xmm6
-       jp       SHORT G_M54452_IG06
+       jp       SHORT G_M33079_IG06
        vucomiss xmm0, xmm6
-       ja       SHORT G_M54452_IG05
+       ja       SHORT G_M33079_IG05
 						;; bbWeight=0.25 PerfScore 1.00
-G_M54452_IG04:
-       jmp      SHORT G_M54452_IG09
+G_M33079_IG04:
+       jmp      SHORT G_M33079_IG09
 						;; bbWeight=0.50 PerfScore 1.00
-G_M54452_IG05:
+G_M33079_IG05:
        vmovaps  xmm0, xmm6
-       jmp      SHORT G_M54452_IG09
+       jmp      SHORT G_M33079_IG09
 						;; bbWeight=0.50 PerfScore 1.12
-G_M54452_IG06:
+G_M33079_IG06:
        vmovaps  xmm1, xmm6
        vmovd    eax, xmm1
        test     eax, eax
-       jl       SHORT G_M54452_IG08
+       jl       SHORT G_M33079_IG08
 						;; bbWeight=0.25 PerfScore 0.62
-G_M54452_IG07:
-       jmp      SHORT G_M54452_IG09
+G_M33079_IG07:
+       jmp      SHORT G_M33079_IG09
 						;; bbWeight=0.50 PerfScore 1.00
-G_M54452_IG08:
+G_M33079_IG08:
        vmovaps  xmm0, xmm6
 						;; bbWeight=0.50 PerfScore 0.12
-G_M54452_IG09:
+G_M33079_IG09:
        call     System.Half:op_Explicit(float):System.Half
        nop      
 						;; bbWeight=1    PerfScore 1.25
-G_M54452_IG10:
+G_M33079_IG10:
        vmovaps  xmm6, qword ptr [rsp+20H]
        add      rsp, 48
        pop      rsi
        ret      
 						;; bbWeight=1    PerfScore 5.75
 
-; Total bytes of code 97, prolog size 14, PerfScore 33.58, (MethodHash=80ea2b4b) for method Silk.NET.Maths.Scalar:Min(System.Half,System.Half):System.Half
+; Total bytes of code 97, prolog size 14, PerfScore 33.58, (MethodHash=319e7ec8) for method JITTest.ScalarHalf:Min(System.Half,System.Half):System.Half
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarHalf:Max(System.Half,System.Half):System.Half
@@ -16758,109 +16710,86 @@ G_M54452_IG10:
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;* V01 arg1         [V01    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V04 tmp2         [V04,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
-;
-; Lcl frame size = 40
-
-G_M59113_IG01:
-       sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M59113_IG02:
-       call     Silk.NET.Maths.Scalar:Max(System.Half,System.Half):System.Half
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M59113_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=3fd21916) for method JITTest.ScalarHalf:Max(System.Half,System.Half):System.Half
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(System.Half,System.Half):System.Half
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
-;* V01 arg1         [V01    ] (  0,  0   )  struct ( 8) zero-ref   
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T02] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V06 tmp4         [V06,T06] (  8,  8.50)   float  ->  mm6         "non-inline candidate call"
-;  V07 tmp5         [V07,T08] (  6,  3.50)   float  ->  mm0         "Inline return value spill temp"
-;  V08 tmp6         [V08,T07] (  6,  7   )   float  ->  mm0         "Inlining Arg"
-;  V09 tmp7         [V09,T05] (  2,  0.50)     int  ->  rax         "Inline return value spill temp"
-;* V10 tmp8         [V10    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
-;  V11 tmp9         [V11,T09] (  2,  0.50)  simd16  ->  mm1         "Inline stloc first use temp"
-;  V12 tmp10        [V12,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V15 tmp13        [V15,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
+;* V08 tmp6         [V08    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
+;  V09 tmp7         [V09,T09] (  8,  8.50)   float  ->  mm6         "non-inline candidate call"
+;  V10 tmp8         [V10,T11] (  6,  3.50)   float  ->  mm0         "Inline return value spill temp"
+;  V11 tmp9         [V11,T10] (  6,  7   )   float  ->  mm0         "Inlining Arg"
+;  V12 tmp10        [V12,T08] (  2,  0.50)     int  ->  rax         "Inline return value spill temp"
+;* V13 tmp11        [V13    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V14 tmp12        [V14,T12] (  2,  0.50)  simd16  ->  mm1         "Inline stloc first use temp"
+;  V15 tmp13        [V15,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V17 tmp15        [V17,T02] (  2,  2   )  ushort  ->  rax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V18 tmp16        [V18,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V19 tmp17        [V19,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V20 tmp18        [V20,T05] (  2,  2   )  ushort  ->  rax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V21 tmp19        [V21,T06] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V22 tmp20        [V22,T07] (  2,  2   )  ushort  ->  rsi         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 48
 
-G_M21738_IG01:
+G_M59113_IG01:
        push     rsi
        sub      rsp, 48
        vzeroupper 
        vmovaps  qword ptr [rsp+20H], xmm6
 						;; bbWeight=1    PerfScore 5.25
-G_M21738_IG02:
+G_M59113_IG02:
        movzx    rsi, dx
        call     System.Half:op_Explicit(System.Half):float
        vmovaps  xmm6, xmm0
        mov      ecx, esi
        call     System.Half:op_Explicit(System.Half):float
        vucomiss xmm6, xmm0
-       jp       SHORT G_M21738_IG03
-       je       SHORT G_M21738_IG07
+       jp       SHORT G_M59113_IG03
+       je       SHORT G_M59113_IG07
 						;; bbWeight=1    PerfScore 5.75
-G_M21738_IG03:
+G_M59113_IG03:
        vucomiss xmm6, xmm6
-       jp       SHORT G_M21738_IG06
+       jp       SHORT G_M59113_IG06
        vucomiss xmm6, xmm0
-       ja       SHORT G_M21738_IG05
+       ja       SHORT G_M59113_IG05
 						;; bbWeight=0.25 PerfScore 1.00
-G_M21738_IG04:
-       jmp      SHORT G_M21738_IG10
+G_M59113_IG04:
+       jmp      SHORT G_M59113_IG10
 						;; bbWeight=0.50 PerfScore 1.00
-G_M21738_IG05:
+G_M59113_IG05:
        vmovaps  xmm0, xmm6
-       jmp      SHORT G_M21738_IG10
+       jmp      SHORT G_M59113_IG10
 						;; bbWeight=0.50 PerfScore 1.12
-G_M21738_IG06:
+G_M59113_IG06:
        vmovaps  xmm0, xmm6
-       jmp      SHORT G_M21738_IG10
+       jmp      SHORT G_M59113_IG10
 						;; bbWeight=0.50 PerfScore 1.12
-G_M21738_IG07:
+G_M59113_IG07:
        vmovaps  xmm1, xmm0
        vmovd    eax, xmm1
        test     eax, eax
-       jl       SHORT G_M21738_IG09
+       jl       SHORT G_M59113_IG09
 						;; bbWeight=0.25 PerfScore 0.62
-G_M21738_IG08:
-       jmp      SHORT G_M21738_IG10
+G_M59113_IG08:
+       jmp      SHORT G_M59113_IG10
 						;; bbWeight=0.50 PerfScore 1.00
-G_M21738_IG09:
+G_M59113_IG09:
        vmovaps  xmm0, xmm6
 						;; bbWeight=0.50 PerfScore 0.12
-G_M21738_IG10:
+G_M59113_IG10:
        call     System.Half:op_Explicit(float):System.Half
        nop      
 						;; bbWeight=1    PerfScore 1.25
-G_M21738_IG11:
+G_M59113_IG11:
        vmovaps  xmm6, qword ptr [rsp+20H]
        add      rsp, 48
        pop      rsi
        ret      
 						;; bbWeight=1    PerfScore 5.75
 
-; Total bytes of code 103, prolog size 14, PerfScore 35.40, (MethodHash=36e9ab15) for method Silk.NET.Maths.Scalar:Max(System.Half,System.Half):System.Half
+; Total bytes of code 103, prolog size 14, PerfScore 35.40, (MethodHash=3fd21916) for method JITTest.ScalarHalf:Max(System.Half,System.Half):System.Half
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarHalf:Larger(System.Half,System.Half):bool
@@ -17051,37 +16980,204 @@ G_M748_IG03:
 ;* V04 tmp1         [V04    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V05 tmp2         [V05    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V06 tmp3         [V06    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V07 tmp4         [V07    ] (  2,  4   )  struct ( 8) [rsp+0x28]   do-not-enreg[SF] "struct address for call/obj"
+;* V07 tmp4         [V07    ] (  0,  0   )  struct ( 8) zero-ref    "struct address for call/obj"
 ;  V08 tmp5         [V08,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
 ;  V09 tmp6         [V09,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
 ;  V10 tmp7         [V10,T02] (  2,  2   )  ushort  ->   r8         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;  V11 tmp8         [V11,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
 ;  V12 tmp9         [V12,T04] (  2,  2   )  ushort  ->  rdx         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
 ;  V13 tmp10        [V13,T05] (  2,  2   )  ushort  ->  rsi         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
-;  V14 tmp11        [V14    ] (  2,  3   )  ushort  ->  [rsp+0x28]   do-not-enreg[] V07._value(offs=0x00) P-DEP "field V07._value (fldOffset=0x0)"
+;  V14 tmp11        [V14,T06] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
 ;
-; Lcl frame size = 48
+; Lcl frame size = 32
 
 G_M2250_IG01:
        push     rsi
-       sub      rsp, 48
+       sub      rsp, 32
 						;; bbWeight=1    PerfScore 1.25
 G_M2250_IG02:
        movzx    rsi, r8w
        call     Silk.NET.Maths.Scalar:Max(System.Half,System.Half):System.Half
-       mov      word  ptr [rsp+28H], ax
-       movzx    rcx, word  ptr [rsp+28H]
+       movzx    rcx, ax
        mov      edx, esi
        call     Silk.NET.Maths.Scalar:Min(System.Half,System.Half):System.Half
        nop      
-						;; bbWeight=1    PerfScore 4.75
+						;; bbWeight=1    PerfScore 3.00
 G_M2250_IG03:
-       add      rsp, 48
+       add      rsp, 32
        pop      rsi
        ret      
 						;; bbWeight=1    PerfScore 1.75
 
-; Total bytes of code 38, prolog size 5, PerfScore 11.55, (MethodHash=a1d5f735) for method JITTest.ScalarHalf:Clamp(System.Half,System.Half,System.Half):System.Half
+; Total bytes of code 31, prolog size 5, PerfScore 9.10, (MethodHash=a1d5f735) for method JITTest.ScalarHalf:Clamp(System.Half,System.Half,System.Half):System.Half
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(System.Half,System.Half):System.Half
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
+;* V01 arg1         [V01    ] (  0,  0   )  struct ( 8) zero-ref   
+;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
+;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
+;  V06 tmp4         [V06,T06] (  8,  8.50)   float  ->  mm6         "non-inline candidate call"
+;  V07 tmp5         [V07,T08] (  6,  3.50)   float  ->  mm0         "Inline return value spill temp"
+;  V08 tmp6         [V08,T07] (  6,  7   )   float  ->  mm0         "Inlining Arg"
+;  V09 tmp7         [V09,T05] (  2,  0.50)     int  ->  rax         "Inline return value spill temp"
+;* V10 tmp8         [V10    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V11 tmp9         [V11,T09] (  2,  0.50)  simd16  ->  mm1         "Inline stloc first use temp"
+;  V12 tmp10        [V12,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T02] (  2,  2   )  ushort  ->  rax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;
+; Lcl frame size = 48
+
+G_M21738_IG01:
+       push     rsi
+       sub      rsp, 48
+       vzeroupper 
+       vmovaps  qword ptr [rsp+20H], xmm6
+						;; bbWeight=1    PerfScore 5.25
+G_M21738_IG02:
+       movzx    rsi, dx
+       call     System.Half:op_Explicit(System.Half):float
+       vmovaps  xmm6, xmm0
+       mov      ecx, esi
+       call     System.Half:op_Explicit(System.Half):float
+       vucomiss xmm6, xmm0
+       jp       SHORT G_M21738_IG03
+       je       SHORT G_M21738_IG07
+						;; bbWeight=1    PerfScore 5.75
+G_M21738_IG03:
+       vucomiss xmm6, xmm6
+       jp       SHORT G_M21738_IG06
+       vucomiss xmm6, xmm0
+       ja       SHORT G_M21738_IG05
+						;; bbWeight=0.25 PerfScore 1.00
+G_M21738_IG04:
+       jmp      SHORT G_M21738_IG10
+						;; bbWeight=0.50 PerfScore 1.00
+G_M21738_IG05:
+       vmovaps  xmm0, xmm6
+       jmp      SHORT G_M21738_IG10
+						;; bbWeight=0.50 PerfScore 1.12
+G_M21738_IG06:
+       vmovaps  xmm0, xmm6
+       jmp      SHORT G_M21738_IG10
+						;; bbWeight=0.50 PerfScore 1.12
+G_M21738_IG07:
+       vmovaps  xmm1, xmm0
+       vmovd    eax, xmm1
+       test     eax, eax
+       jl       SHORT G_M21738_IG09
+						;; bbWeight=0.25 PerfScore 0.62
+G_M21738_IG08:
+       jmp      SHORT G_M21738_IG10
+						;; bbWeight=0.50 PerfScore 1.00
+G_M21738_IG09:
+       vmovaps  xmm0, xmm6
+						;; bbWeight=0.50 PerfScore 0.12
+G_M21738_IG10:
+       call     System.Half:op_Explicit(float):System.Half
+       nop      
+						;; bbWeight=1    PerfScore 1.25
+G_M21738_IG11:
+       vmovaps  xmm6, qword ptr [rsp+20H]
+       add      rsp, 48
+       pop      rsi
+       ret      
+						;; bbWeight=1    PerfScore 5.75
+
+; Total bytes of code 103, prolog size 14, PerfScore 35.40, (MethodHash=36e9ab15) for method Silk.NET.Maths.Scalar:Max(System.Half,System.Half):System.Half
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(System.Half,System.Half):System.Half
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
+;* V01 arg1         [V01    ] (  0,  0   )  struct ( 8) zero-ref   
+;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
+;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
+;  V06 tmp4         [V06,T06] (  8,  8   )   float  ->  mm6         "non-inline candidate call"
+;  V07 tmp5         [V07,T08] (  5,  3   )   float  ->  mm0         "Inline return value spill temp"
+;  V08 tmp6         [V08,T07] (  5,  6.50)   float  ->  mm0         "Inlining Arg"
+;  V09 tmp7         [V09,T05] (  2,  0.50)     int  ->  rax         "Inline return value spill temp"
+;* V10 tmp8         [V10    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V11 tmp9         [V11,T09] (  2,  0.50)  simd16  ->  mm1         "Inline stloc first use temp"
+;  V12 tmp10        [V12,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T02] (  2,  2   )  ushort  ->  rax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T04] (  2,  2   )  ushort  ->  rsi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;
+; Lcl frame size = 48
+
+G_M54452_IG01:
+       push     rsi
+       sub      rsp, 48
+       vzeroupper 
+       vmovaps  qword ptr [rsp+20H], xmm6
+						;; bbWeight=1    PerfScore 5.25
+G_M54452_IG02:
+       movzx    rsi, dx
+       call     System.Half:op_Explicit(System.Half):float
+       vmovaps  xmm6, xmm0
+       mov      ecx, esi
+       call     System.Half:op_Explicit(System.Half):float
+       vucomiss xmm6, xmm0
+       jp       SHORT G_M54452_IG03
+       je       SHORT G_M54452_IG06
+						;; bbWeight=1    PerfScore 5.75
+G_M54452_IG03:
+       vucomiss xmm6, xmm6
+       jp       SHORT G_M54452_IG06
+       vucomiss xmm0, xmm6
+       ja       SHORT G_M54452_IG05
+						;; bbWeight=0.25 PerfScore 1.00
+G_M54452_IG04:
+       jmp      SHORT G_M54452_IG09
+						;; bbWeight=0.50 PerfScore 1.00
+G_M54452_IG05:
+       vmovaps  xmm0, xmm6
+       jmp      SHORT G_M54452_IG09
+						;; bbWeight=0.50 PerfScore 1.12
+G_M54452_IG06:
+       vmovaps  xmm1, xmm6
+       vmovd    eax, xmm1
+       test     eax, eax
+       jl       SHORT G_M54452_IG08
+						;; bbWeight=0.25 PerfScore 0.62
+G_M54452_IG07:
+       jmp      SHORT G_M54452_IG09
+						;; bbWeight=0.50 PerfScore 1.00
+G_M54452_IG08:
+       vmovaps  xmm0, xmm6
+						;; bbWeight=0.50 PerfScore 0.12
+G_M54452_IG09:
+       call     System.Half:op_Explicit(float):System.Half
+       nop      
+						;; bbWeight=1    PerfScore 1.25
+G_M54452_IG10:
+       vmovaps  xmm6, qword ptr [rsp+20H]
+       add      rsp, 48
+       pop      rsi
+       ret      
+						;; bbWeight=1    PerfScore 5.75
+
+; Total bytes of code 97, prolog size 14, PerfScore 33.58, (MethodHash=80ea2b4b) for method Silk.NET.Maths.Scalar:Min(System.Half,System.Half):System.Half
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarHalf:Negate(System.Half):System.Half
@@ -17093,59 +17189,33 @@ G_M2250_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V02 tmp1         [V02,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
+;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
+;* V03 tmp2         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
+;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V06 tmp5         [V06,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 40
 
 G_M28005_IG01:
        sub      rsp, 40
-						;; bbWeight=1    PerfScore 0.25
-G_M28005_IG02:
-       call     Silk.NET.Maths.Scalar:Negate(System.Half):System.Half
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M28005_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 15, prolog size 4, PerfScore 4.25, (MethodHash=ccc8929a) for method JITTest.ScalarHalf:Negate(System.Half):System.Half
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(System.Half):System.Half
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
-;* V01 loc0         [V01    ] (  0,  0   )  struct ( 8) zero-ref    ld-addr-op
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V03 tmp1         [V03,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;* V04 tmp2         [V04    ] (  0,  0   )  ushort  ->  zero-ref    V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
-;
-; Lcl frame size = 40
-
-G_M11590_IG01:
-       sub      rsp, 40
        vzeroupper 
 						;; bbWeight=1    PerfScore 1.25
-G_M11590_IG02:
+G_M28005_IG02:
        call     System.Half:op_Explicit(System.Half):float
        vmovss   xmm1, dword ptr [reloc @RWD00]
        vxorps   xmm0, xmm1
        call     System.Half:op_Explicit(float):System.Half
        nop      
 						;; bbWeight=1    PerfScore 4.58
-G_M11590_IG03:
+G_M28005_IG03:
        add      rsp, 40
        ret      
 						;; bbWeight=1    PerfScore 1.25
 RWD00  dd	80000000h
 
 
-; Total bytes of code 35, prolog size 7, PerfScore 10.78, (MethodHash=8889d2b9) for method Silk.NET.Maths.Scalar:Negate(System.Half):System.Half
+; Total bytes of code 35, prolog size 7, PerfScore 10.78, (MethodHash=ccc8929a) for method JITTest.ScalarHalf:Negate(System.Half):System.Half
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarHalf:Equal(System.Half,System.Half):bool
@@ -17164,16 +17234,12 @@ RWD00  dd	80000000h
 ;  V06 tmp4         [V06,T02] (  2,  2   )    bool  ->  rax         "Inline return value spill temp"
 ;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;* V08 tmp6         [V08    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V09 tmp7         [V09    ] (  2,  4   )  struct ( 8) [rsp+0x20]   do-not-enreg[XS] addr-exposed ld-addr-op "Inlining Arg"
-;* V10 tmp8         [V10    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V11 tmp9         [V11,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T04] (  2,  2   )  ushort  ->  rdx         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
-;  V15 tmp13        [V15,T05] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
-;  V16 tmp14        [V16,T06] (  2,  2   )  ushort  ->  rdx         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
-;  V17 tmp15        [V17    ] (  2,  3   )  ushort  ->  [rsp+0x20]   do-not-enreg[X] addr-exposed V09._value(offs=0x00) P-DEP "field V09._value (fldOffset=0x0)"
-;  V18 tmp16        [V18,T07] (  2,  2   )  ushort  ->  rdx         V10._value(offs=0x00) P-INDEP "field V10._value (fldOffset=0x0)"
+;  V09 tmp7         [V09,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
+;  V10 tmp8         [V10,T01] (  2,  2   )  ushort  ->  rdx         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V11 tmp9         [V11,T03] (  2,  2   )  ushort  ->  rcx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T04] (  2,  2   )  ushort  ->  rdx         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T05] (  2,  2   )  ushort  ->  rcx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T06] (  2,  2   )  ushort  ->  rdx         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 40
 
@@ -17181,17 +17247,15 @@ G_M21591_IG01:
        sub      rsp, 40
 						;; bbWeight=1    PerfScore 0.25
 G_M21591_IG02:
-       mov      word  ptr [rsp+20H], cx
-       lea      rcx, bword ptr [rsp+20H]
-       call     System.Half:Equals(System.Half):bool:this
+       call     System.Half:op_Equality(System.Half,System.Half):bool
        movzx    rax, al
-						;; bbWeight=1    PerfScore 2.75
+						;; bbWeight=1    PerfScore 1.25
 G_M21591_IG03:
        add      rsp, 40
        ret      
 						;; bbWeight=1    PerfScore 1.25
 
-; Total bytes of code 27, prolog size 4, PerfScore 6.95, (MethodHash=5104aba8) for method JITTest.ScalarHalf:Equal(System.Half,System.Half):bool
+; Total bytes of code 17, prolog size 4, PerfScore 4.45, (MethodHash=5104aba8) for method JITTest.ScalarHalf:Equal(System.Half,System.Half):bool
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarHalf:Acos(System.Half):System.Half
@@ -17203,11 +17267,12 @@ G_M21591_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V02 tmp1         [V02,T01] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V03 tmp2         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V05 tmp4         [V05,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V06 rat0         [V06,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V06 tmp5         [V06,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V07 rat0         [V07,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
 ;
 ; Lcl frame size = 40
 
@@ -17238,14 +17303,16 @@ G_M27079_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;* V02 tmp1         [V02    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V03 tmp2         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V04 tmp3         [V04,T01] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V04 tmp3         [V04    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V05 tmp4         [V05    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
-;  V06 tmp5         [V06,T04] (  2,  4   )   float  ->  mm0         "Inlining Arg"
+;  V06 tmp5         [V06,T05] (  2,  4   )   float  ->  mm0         "Inlining Arg"
 ;  V07 tmp6         [V07,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V08 tmp7         [V08,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V09 tmp8         [V09,T03] (  2,  2   )  ushort  ->  rcx         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V08 tmp7         [V08,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V09 tmp8         [V09,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V10 tmp9         [V10,T03] (  2,  2   )  ushort  ->  rax         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V11 tmp10        [V11,T04] (  2,  2   )  ushort  ->  rcx         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 40
 
@@ -17279,12 +17346,13 @@ RWD00  dd	7FFFFFFFh
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V02 tmp1         [V02,T01] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V03 tmp2         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V05 tmp4         [V05,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V06 tmp5         [V06,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
-;  V07 tmp6         [V07,T04] (  2,  4   )   float  ->  mm0         "argument with side effect"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V06 tmp5         [V06,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V07 tmp6         [V07,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
+;  V08 tmp7         [V08,T04] (  2,  4   )   float  ->  mm0         "argument with side effect"
 ;
 ; Lcl frame size = 40
 
@@ -17683,11 +17751,12 @@ RWD640 dd	FFC00000h
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V02 tmp1         [V02,T01] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V03 tmp2         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V05 tmp4         [V05,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V06 rat0         [V06,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V06 tmp5         [V06,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V07 rat0         [V07,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
 ;
 ; Lcl frame size = 40
 
@@ -17718,11 +17787,12 @@ G_M48165_IG03:
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )  struct ( 8) zero-ref   
 ;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;  V02 tmp1         [V02,T01] (  2,  2   )   short  ->  rax         "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 8) zero-ref    "Inline return value spill temp"
 ;* V03 tmp2         [V03    ] (  0,  0   )  struct ( 8) zero-ref    "Inlining Arg"
 ;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  rcx         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
-;  V05 tmp4         [V05,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V06 rat0         [V06,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  rax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V06 tmp5         [V06,T02] (  2,  2   )  ushort  ->  rcx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V07 rat0         [V07,T03] (  2,  4   )   float  ->  mm0         "argument with side effect"
 ;
 ; Lcl frame size = 40
 
@@ -19143,119 +19213,62 @@ G_M23493_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )   float  ->  mm0        
-;  V01 arg1         [V01,T01] (  3,  3   )   float  ->  mm1        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M15612_IG01:
-       sub      rsp, 40
-       vzeroupper 
-						;; bbWeight=1    PerfScore 1.25
-G_M15612_IG02:
-       call     Silk.NET.Maths.Scalar:Min(float,float):float
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M15612_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 18, prolog size 7, PerfScore 5.55, (MethodHash=671dc303) for method JITTest.ScalarFloat:Min(float,float):float
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(float,float):float
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00,T01] (  9,  5   )   float  ->  mm0        
 ;  V01 arg1         [V01,T02] (  6,  4.25)   float  ->  mm1        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
 ;* V03 tmp1         [V03    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
-;  V04 tmp2         [V04,T03] (  5,  3   )   float  ->  mm1         "Inline return value spill temp"
-;  V05 tmp3         [V05,T00] (  2,  0.50)     int  ->  rax         "Inline return value spill temp"
-;* V06 tmp4         [V06    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
-;  V07 tmp5         [V07,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
+;* V04 tmp2         [V04    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
+;  V05 tmp3         [V05,T03] (  5,  3   )   float  ->  mm1         "Inline return value spill temp"
+;  V06 tmp4         [V06,T00] (  2,  0.50)     int  ->  rax         "Inline return value spill temp"
+;* V07 tmp5         [V07    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V08 tmp6         [V08,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
 ;
 ; Lcl frame size = 0
 
-G_M50508_IG01:
+G_M15612_IG01:
        vzeroupper 
 						;; bbWeight=1    PerfScore 1.00
-G_M50508_IG02:
+G_M15612_IG02:
        vucomiss xmm0, xmm1
-       jp       SHORT G_M50508_IG03
-       je       SHORT G_M50508_IG06
+       jp       SHORT G_M15612_IG03
+       je       SHORT G_M15612_IG06
 						;; bbWeight=1    PerfScore 3.00
-G_M50508_IG03:
+G_M15612_IG03:
        vucomiss xmm0, xmm0
-       jp       SHORT G_M50508_IG06
+       jp       SHORT G_M15612_IG06
        vucomiss xmm1, xmm0
-       ja       SHORT G_M50508_IG05
+       ja       SHORT G_M15612_IG05
 						;; bbWeight=0.25 PerfScore 1.00
-G_M50508_IG04:
-       jmp      SHORT G_M50508_IG09
+G_M15612_IG04:
+       jmp      SHORT G_M15612_IG09
 						;; bbWeight=0.50 PerfScore 1.00
-G_M50508_IG05:
+G_M15612_IG05:
        vmovaps  xmm1, xmm0
-       jmp      SHORT G_M50508_IG09
+       jmp      SHORT G_M15612_IG09
 						;; bbWeight=0.50 PerfScore 1.12
-G_M50508_IG06:
+G_M15612_IG06:
        vmovaps  xmm2, xmm0
        vmovd    eax, xmm2
        test     eax, eax
-       jl       SHORT G_M50508_IG08
+       jl       SHORT G_M15612_IG08
 						;; bbWeight=0.25 PerfScore 0.62
-G_M50508_IG07:
-       jmp      SHORT G_M50508_IG09
+G_M15612_IG07:
+       jmp      SHORT G_M15612_IG09
 						;; bbWeight=0.50 PerfScore 1.00
-G_M50508_IG08:
+G_M15612_IG08:
        vmovaps  xmm1, xmm0
 						;; bbWeight=0.50 PerfScore 0.12
-G_M50508_IG09:
+G_M15612_IG09:
        vmovaps  xmm0, xmm1
 						;; bbWeight=1    PerfScore 0.25
-G_M50508_IG10:
+G_M15612_IG10:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 54, prolog size 3, PerfScore 16.33, (MethodHash=1de43ab3) for method Silk.NET.Maths.Scalar:Min(float,float):float
+; Total bytes of code 54, prolog size 3, PerfScore 16.33, (MethodHash=671dc303) for method JITTest.ScalarFloat:Min(float,float):float
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarFloat:Max(float,float):float
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )   float  ->  mm0        
-;  V01 arg1         [V01,T01] (  3,  3   )   float  ->  mm1        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M26530_IG01:
-       sub      rsp, 40
-       vzeroupper 
-						;; bbWeight=1    PerfScore 1.25
-G_M26530_IG02:
-       call     Silk.NET.Maths.Scalar:Max(float,float):float
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M26530_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 18, prolog size 7, PerfScore 5.55, (MethodHash=9671985d) for method JITTest.ScalarFloat:Max(float,float):float
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(float,float):float
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
 ; rsp based frame
@@ -19266,58 +19279,59 @@ G_M26530_IG03:
 ;  V01 arg1         [V01,T02] (  7,  4.50)   float  ->  mm1        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
 ;* V03 tmp1         [V03    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
-;  V04 tmp2         [V04,T03] (  6,  3.50)   float  ->  mm1         "Inline return value spill temp"
-;  V05 tmp3         [V05,T00] (  2,  0.50)     int  ->  rax         "Inline return value spill temp"
-;* V06 tmp4         [V06    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
-;  V07 tmp5         [V07,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
+;* V04 tmp2         [V04    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
+;  V05 tmp3         [V05,T03] (  6,  3.50)   float  ->  mm1         "Inline return value spill temp"
+;  V06 tmp4         [V06,T00] (  2,  0.50)     int  ->  rax         "Inline return value spill temp"
+;* V07 tmp5         [V07    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V08 tmp6         [V08,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
 ;
 ; Lcl frame size = 0
 
-G_M9746_IG01:
+G_M26530_IG01:
        vzeroupper 
 						;; bbWeight=1    PerfScore 1.00
-G_M9746_IG02:
+G_M26530_IG02:
        vucomiss xmm0, xmm1
-       jp       SHORT G_M9746_IG03
-       je       SHORT G_M9746_IG07
+       jp       SHORT G_M26530_IG03
+       je       SHORT G_M26530_IG07
 						;; bbWeight=1    PerfScore 3.00
-G_M9746_IG03:
+G_M26530_IG03:
        vucomiss xmm0, xmm0
-       jp       SHORT G_M9746_IG06
+       jp       SHORT G_M26530_IG06
        vucomiss xmm0, xmm1
-       ja       SHORT G_M9746_IG05
+       ja       SHORT G_M26530_IG05
 						;; bbWeight=0.25 PerfScore 1.00
-G_M9746_IG04:
-       jmp      SHORT G_M9746_IG10
+G_M26530_IG04:
+       jmp      SHORT G_M26530_IG10
 						;; bbWeight=0.50 PerfScore 1.00
-G_M9746_IG05:
+G_M26530_IG05:
        vmovaps  xmm1, xmm0
-       jmp      SHORT G_M9746_IG10
+       jmp      SHORT G_M26530_IG10
 						;; bbWeight=0.50 PerfScore 1.12
-G_M9746_IG06:
+G_M26530_IG06:
        vmovaps  xmm1, xmm0
-       jmp      SHORT G_M9746_IG10
+       jmp      SHORT G_M26530_IG10
 						;; bbWeight=0.50 PerfScore 1.12
-G_M9746_IG07:
+G_M26530_IG07:
        vmovaps  xmm2, xmm1
        vmovd    eax, xmm2
        test     eax, eax
-       jl       SHORT G_M9746_IG09
+       jl       SHORT G_M26530_IG09
 						;; bbWeight=0.25 PerfScore 0.62
-G_M9746_IG08:
-       jmp      SHORT G_M9746_IG10
+G_M26530_IG08:
+       jmp      SHORT G_M26530_IG10
 						;; bbWeight=0.50 PerfScore 1.00
-G_M9746_IG09:
+G_M26530_IG09:
        vmovaps  xmm1, xmm0
 						;; bbWeight=0.50 PerfScore 0.12
-G_M9746_IG10:
+G_M26530_IG10:
        vmovaps  xmm0, xmm1
 						;; bbWeight=1    PerfScore 0.25
-G_M9746_IG11:
+G_M26530_IG11:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 60, prolog size 3, PerfScore 18.15, (MethodHash=ada7d9ed) for method Silk.NET.Maths.Scalar:Max(float,float):float
+; Total bytes of code 60, prolog size 3, PerfScore 18.15, (MethodHash=9671985d) for method JITTest.ScalarFloat:Max(float,float):float
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarFloat:Larger(float,float):bool
@@ -19474,6 +19488,132 @@ G_M12729_IG03:
 ; Total bytes of code 35, prolog size 7, PerfScore 10.95, (MethodHash=430fce46) for method JITTest.ScalarFloat:Clamp(float,float,float):float
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(float,float):float
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T01] (  9,  5.25)   float  ->  mm0        
+;  V01 arg1         [V01,T02] (  7,  4.50)   float  ->  mm1        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;* V03 tmp1         [V03    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T03] (  6,  3.50)   float  ->  mm1         "Inline return value spill temp"
+;  V05 tmp3         [V05,T00] (  2,  0.50)     int  ->  rax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V07 tmp5         [V07,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
+;
+; Lcl frame size = 0
+
+G_M9746_IG01:
+       vzeroupper 
+						;; bbWeight=1    PerfScore 1.00
+G_M9746_IG02:
+       vucomiss xmm0, xmm1
+       jp       SHORT G_M9746_IG03
+       je       SHORT G_M9746_IG07
+						;; bbWeight=1    PerfScore 3.00
+G_M9746_IG03:
+       vucomiss xmm0, xmm0
+       jp       SHORT G_M9746_IG06
+       vucomiss xmm0, xmm1
+       ja       SHORT G_M9746_IG05
+						;; bbWeight=0.25 PerfScore 1.00
+G_M9746_IG04:
+       jmp      SHORT G_M9746_IG10
+						;; bbWeight=0.50 PerfScore 1.00
+G_M9746_IG05:
+       vmovaps  xmm1, xmm0
+       jmp      SHORT G_M9746_IG10
+						;; bbWeight=0.50 PerfScore 1.12
+G_M9746_IG06:
+       vmovaps  xmm1, xmm0
+       jmp      SHORT G_M9746_IG10
+						;; bbWeight=0.50 PerfScore 1.12
+G_M9746_IG07:
+       vmovaps  xmm2, xmm1
+       vmovd    eax, xmm2
+       test     eax, eax
+       jl       SHORT G_M9746_IG09
+						;; bbWeight=0.25 PerfScore 0.62
+G_M9746_IG08:
+       jmp      SHORT G_M9746_IG10
+						;; bbWeight=0.50 PerfScore 1.00
+G_M9746_IG09:
+       vmovaps  xmm1, xmm0
+						;; bbWeight=0.50 PerfScore 0.12
+G_M9746_IG10:
+       vmovaps  xmm0, xmm1
+						;; bbWeight=1    PerfScore 0.25
+G_M9746_IG11:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 60, prolog size 3, PerfScore 18.15, (MethodHash=ada7d9ed) for method Silk.NET.Maths.Scalar:Max(float,float):float
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(float,float):float
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T01] (  9,  5   )   float  ->  mm0        
+;  V01 arg1         [V01,T02] (  6,  4.25)   float  ->  mm1        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;* V03 tmp1         [V03    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T03] (  5,  3   )   float  ->  mm1         "Inline return value spill temp"
+;  V05 tmp3         [V05,T00] (  2,  0.50)     int  ->  rax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V07 tmp5         [V07,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
+;
+; Lcl frame size = 0
+
+G_M50508_IG01:
+       vzeroupper 
+						;; bbWeight=1    PerfScore 1.00
+G_M50508_IG02:
+       vucomiss xmm0, xmm1
+       jp       SHORT G_M50508_IG03
+       je       SHORT G_M50508_IG06
+						;; bbWeight=1    PerfScore 3.00
+G_M50508_IG03:
+       vucomiss xmm0, xmm0
+       jp       SHORT G_M50508_IG06
+       vucomiss xmm1, xmm0
+       ja       SHORT G_M50508_IG05
+						;; bbWeight=0.25 PerfScore 1.00
+G_M50508_IG04:
+       jmp      SHORT G_M50508_IG09
+						;; bbWeight=0.50 PerfScore 1.00
+G_M50508_IG05:
+       vmovaps  xmm1, xmm0
+       jmp      SHORT G_M50508_IG09
+						;; bbWeight=0.50 PerfScore 1.12
+G_M50508_IG06:
+       vmovaps  xmm2, xmm0
+       vmovd    eax, xmm2
+       test     eax, eax
+       jl       SHORT G_M50508_IG08
+						;; bbWeight=0.25 PerfScore 0.62
+G_M50508_IG07:
+       jmp      SHORT G_M50508_IG09
+						;; bbWeight=0.50 PerfScore 1.00
+G_M50508_IG08:
+       vmovaps  xmm1, xmm0
+						;; bbWeight=0.50 PerfScore 0.12
+G_M50508_IG09:
+       vmovaps  xmm0, xmm1
+						;; bbWeight=1    PerfScore 0.25
+G_M50508_IG10:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 54, prolog size 3, PerfScore 16.33, (MethodHash=1de43ab3) for method Silk.NET.Maths.Scalar:Min(float,float):float
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarFloat:Negate(float):float
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
@@ -19482,53 +19622,25 @@ G_M12729_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )   float  ->  mm0        
-;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M20150_IG01:
-       sub      rsp, 40
-       vzeroupper 
-						;; bbWeight=1    PerfScore 1.25
-G_M20150_IG02:
-       call     Silk.NET.Maths.Scalar:Negate(float):float
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M20150_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 18, prolog size 7, PerfScore 5.55, (MethodHash=50f9b149) for method JITTest.ScalarFloat:Negate(float):float
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(float):float
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )   float  ->  mm0        
-;* V01 loc0         [V01    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op
-;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V02 tmp1         [V02,T01] (  2,  2   )   float  ->  mm0         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M40518_IG01:
+G_M20150_IG01:
        vzeroupper 
 						;; bbWeight=1    PerfScore 1.00
-G_M40518_IG02:
+G_M20150_IG02:
        vmovss   xmm1, dword ptr [reloc @RWD00]
        vxorps   xmm0, xmm1
 						;; bbWeight=1    PerfScore 2.33
-G_M40518_IG03:
+G_M20150_IG03:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 RWD00  dd	80000000h
 
 
-; Total bytes of code 16, prolog size 3, PerfScore 6.13, (MethodHash=c9b261b9) for method Silk.NET.Maths.Scalar:Negate(float):float
+; Total bytes of code 16, prolog size 3, PerfScore 6.13, (MethodHash=50f9b149) for method JITTest.ScalarFloat:Negate(float):float
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarFloat:Equal(float,float):bool
@@ -21114,119 +21226,62 @@ G_M43461_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )  double  ->  mm0        
-;  V01 arg1         [V01,T01] (  3,  3   )  double  ->  mm1        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M43772_IG01:
-       sub      rsp, 40
-       vzeroupper 
-						;; bbWeight=1    PerfScore 1.25
-G_M43772_IG02:
-       call     Silk.NET.Maths.Scalar:Min(double,double):double
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M43772_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 18, prolog size 7, PerfScore 5.55, (MethodHash=a5dd5503) for method JITTest.ScalarDouble:Min(double,double):double
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(double,double):double
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00,T01] (  9,  5   )  double  ->  mm0        
 ;  V01 arg1         [V01,T02] (  6,  4.25)  double  ->  mm1        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
 ;* V03 tmp1         [V03    ] (  0,  0   )  double  ->  zero-ref    "Inline return value spill temp"
-;  V04 tmp2         [V04,T03] (  5,  3   )  double  ->  mm1         "Inline return value spill temp"
-;  V05 tmp3         [V05,T00] (  2,  0.50)    long  ->  rax         "Inline return value spill temp"
-;* V06 tmp4         [V06    ] (  0,  0   )  double  ->  zero-ref    ld-addr-op "Inlining Arg"
-;  V07 tmp5         [V07,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
+;* V04 tmp2         [V04    ] (  0,  0   )  double  ->  zero-ref    "Inline return value spill temp"
+;  V05 tmp3         [V05,T03] (  5,  3   )  double  ->  mm1         "Inline return value spill temp"
+;  V06 tmp4         [V06,T00] (  2,  0.50)    long  ->  rax         "Inline return value spill temp"
+;* V07 tmp5         [V07    ] (  0,  0   )  double  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V08 tmp6         [V08,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
 ;
 ; Lcl frame size = 0
 
-G_M52969_IG01:
+G_M43772_IG01:
        vzeroupper 
 						;; bbWeight=1    PerfScore 1.00
-G_M52969_IG02:
+G_M43772_IG02:
        vucomisd xmm0, xmm1
-       jp       SHORT G_M52969_IG03
-       je       SHORT G_M52969_IG06
+       jp       SHORT G_M43772_IG03
+       je       SHORT G_M43772_IG06
 						;; bbWeight=1    PerfScore 3.00
-G_M52969_IG03:
+G_M43772_IG03:
        vucomisd xmm0, xmm0
-       jp       SHORT G_M52969_IG06
+       jp       SHORT G_M43772_IG06
        vucomisd xmm1, xmm0
-       ja       SHORT G_M52969_IG05
+       ja       SHORT G_M43772_IG05
 						;; bbWeight=0.25 PerfScore 1.00
-G_M52969_IG04:
-       jmp      SHORT G_M52969_IG09
+G_M43772_IG04:
+       jmp      SHORT G_M43772_IG09
 						;; bbWeight=0.50 PerfScore 1.00
-G_M52969_IG05:
+G_M43772_IG05:
        vmovaps  xmm1, xmm0
-       jmp      SHORT G_M52969_IG09
+       jmp      SHORT G_M43772_IG09
 						;; bbWeight=0.50 PerfScore 1.12
-G_M52969_IG06:
+G_M43772_IG06:
        vmovaps  xmm2, xmm0
        vmovd    rax, xmm2
        test     rax, rax
-       jl       SHORT G_M52969_IG08
+       jl       SHORT G_M43772_IG08
 						;; bbWeight=0.25 PerfScore 0.62
-G_M52969_IG07:
-       jmp      SHORT G_M52969_IG09
+G_M43772_IG07:
+       jmp      SHORT G_M43772_IG09
 						;; bbWeight=0.50 PerfScore 1.00
-G_M52969_IG08:
+G_M43772_IG08:
        vmovaps  xmm1, xmm0
 						;; bbWeight=0.50 PerfScore 0.12
-G_M52969_IG09:
+G_M43772_IG09:
        vmovaps  xmm0, xmm1
 						;; bbWeight=1    PerfScore 0.25
-G_M52969_IG10:
+G_M43772_IG10:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 56, prolog size 3, PerfScore 16.43, (MethodHash=4bad3116) for method Silk.NET.Maths.Scalar:Min(double,double):double
+; Total bytes of code 56, prolog size 3, PerfScore 16.43, (MethodHash=a5dd5503) for method JITTest.ScalarDouble:Min(double,double):double
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarDouble:Max(double,double):double
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )  double  ->  mm0        
-;  V01 arg1         [V01,T01] (  3,  3   )  double  ->  mm1        
-;  V02 OutArgs      [V02    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M44770_IG01:
-       sub      rsp, 40
-       vzeroupper 
-						;; bbWeight=1    PerfScore 1.25
-G_M44770_IG02:
-       call     Silk.NET.Maths.Scalar:Max(double,double):double
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M44770_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 18, prolog size 7, PerfScore 5.55, (MethodHash=ad4d511d) for method JITTest.ScalarDouble:Max(double,double):double
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(double,double):double
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
 ; rsp based frame
@@ -21237,58 +21292,59 @@ G_M44770_IG03:
 ;  V01 arg1         [V01,T02] (  7,  4.50)  double  ->  mm1        
 ;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
 ;* V03 tmp1         [V03    ] (  0,  0   )  double  ->  zero-ref    "Inline return value spill temp"
-;  V04 tmp2         [V04,T03] (  6,  3.50)  double  ->  mm1         "Inline return value spill temp"
-;  V05 tmp3         [V05,T00] (  2,  0.50)    long  ->  rax         "Inline return value spill temp"
-;* V06 tmp4         [V06    ] (  0,  0   )  double  ->  zero-ref    ld-addr-op "Inlining Arg"
-;  V07 tmp5         [V07,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
+;* V04 tmp2         [V04    ] (  0,  0   )  double  ->  zero-ref    "Inline return value spill temp"
+;  V05 tmp3         [V05,T03] (  6,  3.50)  double  ->  mm1         "Inline return value spill temp"
+;  V06 tmp4         [V06,T00] (  2,  0.50)    long  ->  rax         "Inline return value spill temp"
+;* V07 tmp5         [V07    ] (  0,  0   )  double  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V08 tmp6         [V08,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
 ;
 ; Lcl frame size = 0
 
-G_M47351_IG01:
+G_M44770_IG01:
        vzeroupper 
 						;; bbWeight=1    PerfScore 1.00
-G_M47351_IG02:
+G_M44770_IG02:
        vucomisd xmm0, xmm1
-       jp       SHORT G_M47351_IG03
-       je       SHORT G_M47351_IG07
+       jp       SHORT G_M44770_IG03
+       je       SHORT G_M44770_IG07
 						;; bbWeight=1    PerfScore 3.00
-G_M47351_IG03:
+G_M44770_IG03:
        vucomisd xmm0, xmm0
-       jp       SHORT G_M47351_IG06
+       jp       SHORT G_M44770_IG06
        vucomisd xmm0, xmm1
-       ja       SHORT G_M47351_IG05
+       ja       SHORT G_M44770_IG05
 						;; bbWeight=0.25 PerfScore 1.00
-G_M47351_IG04:
-       jmp      SHORT G_M47351_IG10
+G_M44770_IG04:
+       jmp      SHORT G_M44770_IG10
 						;; bbWeight=0.50 PerfScore 1.00
-G_M47351_IG05:
+G_M44770_IG05:
        vmovaps  xmm1, xmm0
-       jmp      SHORT G_M47351_IG10
+       jmp      SHORT G_M44770_IG10
 						;; bbWeight=0.50 PerfScore 1.12
-G_M47351_IG06:
+G_M44770_IG06:
        vmovaps  xmm1, xmm0
-       jmp      SHORT G_M47351_IG10
+       jmp      SHORT G_M44770_IG10
 						;; bbWeight=0.50 PerfScore 1.12
-G_M47351_IG07:
+G_M44770_IG07:
        vmovaps  xmm2, xmm1
        vmovd    rax, xmm2
        test     rax, rax
-       jl       SHORT G_M47351_IG09
+       jl       SHORT G_M44770_IG09
 						;; bbWeight=0.25 PerfScore 0.62
-G_M47351_IG08:
-       jmp      SHORT G_M47351_IG10
+G_M44770_IG08:
+       jmp      SHORT G_M44770_IG10
 						;; bbWeight=0.50 PerfScore 1.00
-G_M47351_IG09:
+G_M44770_IG09:
        vmovaps  xmm1, xmm0
 						;; bbWeight=0.50 PerfScore 0.12
-G_M47351_IG10:
+G_M44770_IG10:
        vmovaps  xmm0, xmm1
 						;; bbWeight=1    PerfScore 0.25
-G_M47351_IG11:
+G_M44770_IG11:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 
-; Total bytes of code 62, prolog size 3, PerfScore 18.25, (MethodHash=b0584708) for method Silk.NET.Maths.Scalar:Max(double,double):double
+; Total bytes of code 62, prolog size 3, PerfScore 18.25, (MethodHash=ad4d511d) for method JITTest.ScalarDouble:Max(double,double):double
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarDouble:Larger(double,double):bool
@@ -21445,6 +21501,132 @@ G_M49084_IG03:
 ; Total bytes of code 35, prolog size 7, PerfScore 10.95, (MethodHash=95794043) for method JITTest.ScalarDouble:Clamp(double,double,double):double
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(double,double):double
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T01] (  9,  5.25)  double  ->  mm0        
+;  V01 arg1         [V01,T02] (  7,  4.50)  double  ->  mm1        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;* V03 tmp1         [V03    ] (  0,  0   )  double  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T03] (  6,  3.50)  double  ->  mm1         "Inline return value spill temp"
+;  V05 tmp3         [V05,T00] (  2,  0.50)    long  ->  rax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )  double  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V07 tmp5         [V07,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
+;
+; Lcl frame size = 0
+
+G_M47351_IG01:
+       vzeroupper 
+						;; bbWeight=1    PerfScore 1.00
+G_M47351_IG02:
+       vucomisd xmm0, xmm1
+       jp       SHORT G_M47351_IG03
+       je       SHORT G_M47351_IG07
+						;; bbWeight=1    PerfScore 3.00
+G_M47351_IG03:
+       vucomisd xmm0, xmm0
+       jp       SHORT G_M47351_IG06
+       vucomisd xmm0, xmm1
+       ja       SHORT G_M47351_IG05
+						;; bbWeight=0.25 PerfScore 1.00
+G_M47351_IG04:
+       jmp      SHORT G_M47351_IG10
+						;; bbWeight=0.50 PerfScore 1.00
+G_M47351_IG05:
+       vmovaps  xmm1, xmm0
+       jmp      SHORT G_M47351_IG10
+						;; bbWeight=0.50 PerfScore 1.12
+G_M47351_IG06:
+       vmovaps  xmm1, xmm0
+       jmp      SHORT G_M47351_IG10
+						;; bbWeight=0.50 PerfScore 1.12
+G_M47351_IG07:
+       vmovaps  xmm2, xmm1
+       vmovd    rax, xmm2
+       test     rax, rax
+       jl       SHORT G_M47351_IG09
+						;; bbWeight=0.25 PerfScore 0.62
+G_M47351_IG08:
+       jmp      SHORT G_M47351_IG10
+						;; bbWeight=0.50 PerfScore 1.00
+G_M47351_IG09:
+       vmovaps  xmm1, xmm0
+						;; bbWeight=0.50 PerfScore 0.12
+G_M47351_IG10:
+       vmovaps  xmm0, xmm1
+						;; bbWeight=1    PerfScore 0.25
+G_M47351_IG11:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 62, prolog size 3, PerfScore 18.25, (MethodHash=b0584708) for method Silk.NET.Maths.Scalar:Max(double,double):double
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(double,double):double
+; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
+; optimized code
+; rsp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T01] (  9,  5   )  double  ->  mm0        
+;  V01 arg1         [V01,T02] (  6,  4.25)  double  ->  mm1        
+;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;* V03 tmp1         [V03    ] (  0,  0   )  double  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T03] (  5,  3   )  double  ->  mm1         "Inline return value spill temp"
+;  V05 tmp3         [V05,T00] (  2,  0.50)    long  ->  rax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )  double  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V07 tmp5         [V07,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
+;
+; Lcl frame size = 0
+
+G_M52969_IG01:
+       vzeroupper 
+						;; bbWeight=1    PerfScore 1.00
+G_M52969_IG02:
+       vucomisd xmm0, xmm1
+       jp       SHORT G_M52969_IG03
+       je       SHORT G_M52969_IG06
+						;; bbWeight=1    PerfScore 3.00
+G_M52969_IG03:
+       vucomisd xmm0, xmm0
+       jp       SHORT G_M52969_IG06
+       vucomisd xmm1, xmm0
+       ja       SHORT G_M52969_IG05
+						;; bbWeight=0.25 PerfScore 1.00
+G_M52969_IG04:
+       jmp      SHORT G_M52969_IG09
+						;; bbWeight=0.50 PerfScore 1.00
+G_M52969_IG05:
+       vmovaps  xmm1, xmm0
+       jmp      SHORT G_M52969_IG09
+						;; bbWeight=0.50 PerfScore 1.12
+G_M52969_IG06:
+       vmovaps  xmm2, xmm0
+       vmovd    rax, xmm2
+       test     rax, rax
+       jl       SHORT G_M52969_IG08
+						;; bbWeight=0.25 PerfScore 0.62
+G_M52969_IG07:
+       jmp      SHORT G_M52969_IG09
+						;; bbWeight=0.50 PerfScore 1.00
+G_M52969_IG08:
+       vmovaps  xmm1, xmm0
+						;; bbWeight=0.50 PerfScore 0.12
+G_M52969_IG09:
+       vmovaps  xmm0, xmm1
+						;; bbWeight=1    PerfScore 0.25
+G_M52969_IG10:
+       ret      
+						;; bbWeight=1    PerfScore 1.00
+
+; Total bytes of code 56, prolog size 3, PerfScore 16.43, (MethodHash=4bad3116) for method Silk.NET.Maths.Scalar:Min(double,double):double
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarDouble:Negate(double):double
 ; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
 ; optimized code
@@ -21453,54 +21635,26 @@ G_M49084_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )  double  ->  mm0        
-;  V01 OutArgs      [V01    ] (  1,  1   )  lclBlk (32) [rsp+0x00]   "OutgoingArgSpace"
-;
-; Lcl frame size = 40
-
-G_M14451_IG01:
-       sub      rsp, 40
-       vzeroupper 
-						;; bbWeight=1    PerfScore 1.25
-G_M14451_IG02:
-       call     Silk.NET.Maths.Scalar:Negate(double):double
-       nop      
-						;; bbWeight=1    PerfScore 1.25
-G_M14451_IG03:
-       add      rsp, 40
-       ret      
-						;; bbWeight=1    PerfScore 1.25
-
-; Total bytes of code 18, prolog size 7, PerfScore 5.55, (MethodHash=2b35c78c) for method JITTest.ScalarDouble:Negate(double):double
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(double):double
-; Emitting BLENDED_CODE for X64 CPU with AVX - Windows
-; optimized code
-; rsp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )  double  ->  mm0        
-;* V01 loc0         [V01    ] (  0,  0   )  double  ->  zero-ref    ld-addr-op
-;# V02 OutArgs      [V02    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;# V01 OutArgs      [V01    ] (  1,  1   )  lclBlk ( 0) [rsp+0x00]   "OutgoingArgSpace"
+;  V02 tmp1         [V02,T01] (  2,  2   )  double  ->  mm0         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
-G_M6886_IG01:
+G_M14451_IG01:
        vzeroupper 
 						;; bbWeight=1    PerfScore 1.00
-G_M6886_IG02:
+G_M14451_IG02:
        vmovsd   xmm1, qword ptr [reloc @RWD08]
        vxorps   xmm0, xmm1
 						;; bbWeight=1    PerfScore 2.33
-G_M6886_IG03:
+G_M14451_IG03:
        ret      
 						;; bbWeight=1    PerfScore 1.00
 RWD00  dq	0000000000000000h
 RWD08  dq	8000000000000000h
 
 
-; Total bytes of code 16, prolog size 3, PerfScore 6.13, (MethodHash=38f1e519) for method Silk.NET.Maths.Scalar:Negate(double):double
+; Total bytes of code 16, prolog size 3, PerfScore 6.13, (MethodHash=2b35c78c) for method JITTest.ScalarDouble:Negate(double):double
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarDouble:Equal(double,double):bool

--- a/build/maths/windows-jit-asm-x86
+++ b/build/maths/windows-jit-asm-x86
@@ -513,7 +513,7 @@ G_M28871_IG02:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;* V00 tmp0         [V00,T00] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -539,7 +539,7 @@ G_M19083_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;* V00 tmp0         [V00,T00] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -566,7 +566,7 @@ G_M62371_IG03:
 ; Final local variable assignments
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )   ubyte  ->  zero-ref   
-;* V01 tmp0         [V01,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -933,6 +933,10 @@ G_M32304_IG03:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )   ubyte  ->  ecx        
 ;  V01 arg1         [V01,T01] (  3,  3   )   ubyte  ->  edx        
+;* V02 tmp0         [V02    ] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T04] (  3,  2   )   ubyte  ->  edx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
@@ -941,58 +945,26 @@ G_M59209_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M59209_IG02:
-       movzx    ecx, cl
-       movzx    edx, dl
-       call     Silk.NET.Maths.Scalar:Min(ubyte,ubyte):ubyte
-						;; bbWeight=1    PerfScore 1.50
-G_M59209_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 16, prolog size 3, PerfScore 5.85, (MethodHash=5c4118b6) for method JITTest.ScalarByte:Min(ubyte,ubyte):ubyte
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(ubyte,ubyte):ubyte
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )   ubyte  ->  ecx        
-;  V01 arg1         [V01,T01] (  3,  3   )   ubyte  ->  edx        
-;  V02 tmp0         [V02,T04] (  3,  2   )   ubyte  ->  edx         "Inline return value spill temp"
-;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
-;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
-;
-; Lcl frame size = 0
-
-G_M13475_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M13475_IG02:
        movzx    eax, cl
        movzx    edx, dl
        cmp      eax, edx
-       jle      SHORT G_M13475_IG04
+       jle      SHORT G_M59209_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M13475_IG03:
-       jmp      SHORT G_M13475_IG05
+G_M59209_IG03:
+       jmp      SHORT G_M59209_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M13475_IG04:
+G_M59209_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M13475_IG05:
+G_M59209_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M13475_IG06:
+G_M59209_IG06:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=ac01cb5c) for method Silk.NET.Maths.Scalar:Min(ubyte,ubyte):ubyte
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=5c4118b6) for method JITTest.ScalarByte:Min(ubyte,ubyte):ubyte
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarByte:Max(ubyte,ubyte):ubyte
@@ -1004,6 +976,10 @@ G_M13475_IG06:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )   ubyte  ->  ecx        
 ;  V01 arg1         [V01,T01] (  3,  3   )   ubyte  ->  edx        
+;* V02 tmp0         [V02    ] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T04] (  3,  2   )   ubyte  ->  edx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
@@ -1012,58 +988,26 @@ G_M5143_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M5143_IG02:
-       movzx    ecx, cl
-       movzx    edx, dl
-       call     Silk.NET.Maths.Scalar:Max(ubyte,ubyte):ubyte
-						;; bbWeight=1    PerfScore 1.50
-G_M5143_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 16, prolog size 3, PerfScore 5.85, (MethodHash=0e69ebe8) for method JITTest.ScalarByte:Max(ubyte,ubyte):ubyte
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(ubyte,ubyte):ubyte
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )   ubyte  ->  ecx        
-;  V01 arg1         [V01,T01] (  3,  3   )   ubyte  ->  edx        
-;  V02 tmp0         [V02,T04] (  3,  2   )   ubyte  ->  edx         "Inline return value spill temp"
-;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
-;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
-;
-; Lcl frame size = 0
-
-G_M12541_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M12541_IG02:
        movzx    eax, cl
        movzx    edx, dl
        cmp      eax, edx
-       jge      SHORT G_M12541_IG04
+       jge      SHORT G_M5143_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M12541_IG03:
-       jmp      SHORT G_M12541_IG05
+G_M5143_IG03:
+       jmp      SHORT G_M5143_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M12541_IG04:
+G_M5143_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M12541_IG05:
+G_M5143_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M12541_IG06:
+G_M5143_IG06:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=2d41cf02) for method Silk.NET.Maths.Scalar:Max(ubyte,ubyte):ubyte
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=0e69ebe8) for method JITTest.ScalarByte:Max(ubyte,ubyte):ubyte
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarByte:Larger(ubyte,ubyte):bool
@@ -1232,7 +1176,7 @@ G_M17859_IG03:
 ; Total bytes of code 36, prolog size 4, PerfScore 13.10, (MethodHash=4545ba3c) for method JITTest.ScalarByte:Clamp(ubyte,ubyte,ubyte):ubyte
 ; ============================================================
 
-; Assembly listing for method JITTest.ScalarByte:Negate(ubyte):ubyte
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(ubyte,ubyte):ubyte
 ; Emitting BLENDED_CODE for generic X86 CPU - Windows
 ; optimized code
 ; ebp based frame
@@ -1240,6 +1184,92 @@ G_M17859_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )   ubyte  ->  ecx        
+;  V01 arg1         [V01,T01] (  3,  3   )   ubyte  ->  edx        
+;  V02 tmp0         [V02,T04] (  3,  2   )   ubyte  ->  edx         "Inline return value spill temp"
+;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M12541_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M12541_IG02:
+       movzx    eax, cl
+       movzx    edx, dl
+       cmp      eax, edx
+       jge      SHORT G_M12541_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M12541_IG03:
+       jmp      SHORT G_M12541_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M12541_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M12541_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M12541_IG06:
+       pop      ebp
+       ret      
+						;; bbWeight=1    PerfScore 1.50
+
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=2d41cf02) for method Silk.NET.Maths.Scalar:Max(ubyte,ubyte):ubyte
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(ubyte,ubyte):ubyte
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  3,  3   )   ubyte  ->  ecx        
+;  V01 arg1         [V01,T01] (  3,  3   )   ubyte  ->  edx        
+;  V02 tmp0         [V02,T04] (  3,  2   )   ubyte  ->  edx         "Inline return value spill temp"
+;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M13475_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M13475_IG02:
+       movzx    eax, cl
+       movzx    edx, dl
+       cmp      eax, edx
+       jle      SHORT G_M13475_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M13475_IG03:
+       jmp      SHORT G_M13475_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M13475_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M13475_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M13475_IG06:
+       pop      ebp
+       ret      
+						;; bbWeight=1    PerfScore 1.50
+
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=ac01cb5c) for method Silk.NET.Maths.Scalar:Min(ubyte,ubyte):ubyte
+; ============================================================
+
+; Assembly listing for method JITTest.ScalarByte:Negate(ubyte):ubyte
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;* V00 arg0         [V00    ] (  0,  0   )   ubyte  ->  zero-ref   
+;* V01 tmp0         [V01    ] (  0,  0   )   ubyte  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )   ubyte  ->  zero-ref    ld-addr-op "Inline ldloca(s) first use temp"
 ;
 ; Lcl frame size = 0
 
@@ -1248,39 +1278,11 @@ G_M26380_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M26380_IG02:
-       movzx    ecx, cl
-       call     Silk.NET.Maths.Scalar:Negate(ubyte):ubyte
-						;; bbWeight=1    PerfScore 1.25
-G_M26380_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 13, prolog size 3, PerfScore 5.30, (MethodHash=adaf98f3) for method JITTest.ScalarByte:Negate(ubyte):ubyte
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(ubyte):ubyte
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;* V00 arg0         [V00    ] (  0,  0   )   ubyte  ->  zero-ref   
-;* V01 loc0         [V01    ] (  0,  0   )   ubyte  ->  zero-ref    ld-addr-op
-;
-; Lcl frame size = 0
-
-G_M58726_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M58726_IG02:
        call     Silk.NET.Maths.Scalar:ThrowInvalidType()
        int3     
 						;; bbWeight=0    PerfScore 0.00
 
-; Total bytes of code 9, prolog size 3, PerfScore 2.15, (MethodHash=530f1a99) for method Silk.NET.Maths.Scalar:Negate(ubyte):ubyte
+; Total bytes of code 9, prolog size 3, PerfScore 2.15, (MethodHash=adaf98f3) for method JITTest.ScalarByte:Negate(ubyte):ubyte
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarByte:Equal(ubyte,ubyte):bool
@@ -1888,7 +1890,7 @@ G_M6740_IG02:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;* V00 tmp0         [V00,T00] (  0,  0   )    byte  ->  zero-ref    "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )    byte  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -1914,7 +1916,7 @@ G_M16493_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;* V00 tmp0         [V00,T00] (  0,  0   )    byte  ->  zero-ref    "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )    byte  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -1941,7 +1943,7 @@ G_M25605_IG03:
 ; Final local variable assignments
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )    byte  ->  zero-ref   
-;* V01 tmp0         [V01,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -2308,6 +2310,10 @@ G_M18614_IG03:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  ecx        
 ;  V01 arg1         [V01,T01] (  3,  3   )    byte  ->  edx        
+;* V02 tmp0         [V02    ] (  0,  0   )    byte  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T04] (  3,  2   )    byte  ->  edx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
@@ -2316,58 +2322,26 @@ G_M38415_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M38415_IG02:
-       movsx    ecx, cl
-       movsx    edx, dl
-       call     Silk.NET.Maths.Scalar:Min(byte,byte):byte
-						;; bbWeight=1    PerfScore 1.50
-G_M38415_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 16, prolog size 3, PerfScore 5.85, (MethodHash=b61169f0) for method JITTest.ScalarSByte:Min(byte,byte):byte
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(byte,byte):byte
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  ecx        
-;  V01 arg1         [V01,T01] (  3,  3   )    byte  ->  edx        
-;  V02 tmp0         [V02,T04] (  3,  2   )    byte  ->  edx         "Inline return value spill temp"
-;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
-;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
-;
-; Lcl frame size = 0
-
-G_M1654_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M1654_IG02:
        movsx    eax, cl
        movsx    edx, dl
        cmp      eax, edx
-       jle      SHORT G_M1654_IG04
+       jle      SHORT G_M38415_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M1654_IG03:
-       jmp      SHORT G_M1654_IG05
+G_M38415_IG03:
+       jmp      SHORT G_M38415_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M1654_IG04:
+G_M38415_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M1654_IG05:
+G_M38415_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M1654_IG06:
+G_M38415_IG06:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=9c4bf989) for method Silk.NET.Maths.Scalar:Min(byte,byte):byte
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=b61169f0) for method JITTest.ScalarSByte:Min(byte,byte):byte
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarSByte:Max(byte,byte):byte
@@ -2379,6 +2353,10 @@ G_M1654_IG06:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  ecx        
 ;  V01 arg1         [V01,T01] (  3,  3   )    byte  ->  edx        
+;* V02 tmp0         [V02    ] (  0,  0   )    byte  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T04] (  3,  2   )    byte  ->  edx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
@@ -2387,58 +2365,26 @@ G_M51473_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M51473_IG02:
-       movsx    ecx, cl
-       movsx    edx, dl
-       call     Silk.NET.Maths.Scalar:Max(byte,byte):byte
-						;; bbWeight=1    PerfScore 1.50
-G_M51473_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 16, prolog size 3, PerfScore 5.85, (MethodHash=578236ee) for method JITTest.ScalarSByte:Max(byte,byte):byte
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(byte,byte):byte
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  ecx        
-;  V01 arg1         [V01,T01] (  3,  3   )    byte  ->  edx        
-;  V02 tmp0         [V02,T04] (  3,  2   )    byte  ->  edx         "Inline return value spill temp"
-;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
-;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
-;
-; Lcl frame size = 0
-
-G_M4456_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M4456_IG02:
        movsx    eax, cl
        movsx    edx, dl
        cmp      eax, edx
-       jge      SHORT G_M4456_IG04
+       jge      SHORT G_M51473_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M4456_IG03:
-       jmp      SHORT G_M4456_IG05
+G_M51473_IG03:
+       jmp      SHORT G_M51473_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M4456_IG04:
+G_M51473_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M4456_IG05:
+G_M51473_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M4456_IG06:
+G_M51473_IG06:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=bb37ee97) for method Silk.NET.Maths.Scalar:Max(byte,byte):byte
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=578236ee) for method JITTest.ScalarSByte:Max(byte,byte):byte
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarSByte:Larger(byte,byte):bool
@@ -2607,6 +2553,90 @@ G_M54704_IG03:
 ; Total bytes of code 36, prolog size 4, PerfScore 13.10, (MethodHash=f0792a4f) for method JITTest.ScalarSByte:Clamp(byte,byte,byte):byte
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(byte,byte):byte
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  ecx        
+;  V01 arg1         [V01,T01] (  3,  3   )    byte  ->  edx        
+;  V02 tmp0         [V02,T04] (  3,  2   )    byte  ->  edx         "Inline return value spill temp"
+;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M4456_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M4456_IG02:
+       movsx    eax, cl
+       movsx    edx, dl
+       cmp      eax, edx
+       jge      SHORT G_M4456_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M4456_IG03:
+       jmp      SHORT G_M4456_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M4456_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M4456_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M4456_IG06:
+       pop      ebp
+       ret      
+						;; bbWeight=1    PerfScore 1.50
+
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=bb37ee97) for method Silk.NET.Maths.Scalar:Max(byte,byte):byte
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(byte,byte):byte
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  ecx        
+;  V01 arg1         [V01,T01] (  3,  3   )    byte  ->  edx        
+;  V02 tmp0         [V02,T04] (  3,  2   )    byte  ->  edx         "Inline return value spill temp"
+;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M1654_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M1654_IG02:
+       movsx    eax, cl
+       movsx    edx, dl
+       cmp      eax, edx
+       jle      SHORT G_M1654_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M1654_IG03:
+       jmp      SHORT G_M1654_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M1654_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M1654_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M1654_IG06:
+       pop      ebp
+       ret      
+						;; bbWeight=1    PerfScore 1.50
+
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=9c4bf989) for method Silk.NET.Maths.Scalar:Min(byte,byte):byte
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarSByte:Negate(byte):byte
 ; Emitting BLENDED_CODE for generic X86 CPU - Windows
 ; optimized code
@@ -2615,6 +2645,7 @@ G_M54704_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  ecx        
+;  V01 tmp0         [V01,T01] (  2,  2   )    byte  ->  eax         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -2623,44 +2654,16 @@ G_M19743_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M19743_IG02:
-       movsx    ecx, cl
-       call     Silk.NET.Maths.Scalar:Negate(byte):byte
-						;; bbWeight=1    PerfScore 1.25
+       movsx    eax, cl
+       neg      eax
+       movsx    eax, al
+						;; bbWeight=1    PerfScore 0.75
 G_M19743_IG03:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 13, prolog size 3, PerfScore 5.30, (MethodHash=3bb5b2e0) for method JITTest.ScalarSByte:Negate(byte):byte
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(byte):byte
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )    byte  ->  ecx        
-;* V01 loc0         [V01    ] (  0,  0   )    byte  ->  zero-ref    ld-addr-op
-;
-; Lcl frame size = 0
-
-G_M23654_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M23654_IG02:
-       movsx    eax, cl
-       neg      eax
-       movsx    eax, al
-						;; bbWeight=1    PerfScore 0.75
-G_M23654_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 13, prolog size 3, PerfScore 4.80, (MethodHash=749da399) for method Silk.NET.Maths.Scalar:Negate(byte):byte
+; Total bytes of code 13, prolog size 3, PerfScore 4.80, (MethodHash=3bb5b2e0) for method JITTest.ScalarSByte:Negate(byte):byte
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarSByte:Equal(byte,byte):bool
@@ -3278,7 +3281,7 @@ G_M59018_IG02:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;* V00 tmp0         [V00,T00] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -3304,7 +3307,7 @@ G_M13342_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;* V00 tmp0         [V00,T00] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -3331,7 +3334,7 @@ G_M52406_IG03:
 ; Final local variable assignments
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )  ushort  ->  zero-ref   
-;* V01 tmp0         [V01,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -3698,6 +3701,10 @@ G_M18149_IG03:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )  ushort  ->  ecx        
 ;  V01 arg1         [V01,T01] (  3,  3   )  ushort  ->  edx        
+;* V02 tmp0         [V02    ] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T04] (  3,  2   )  ushort  ->  edx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
@@ -3706,58 +3713,26 @@ G_M41244_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M41244_IG02:
-       movzx    ecx, cx
-       movzx    edx, dx
-       call     Silk.NET.Maths.Scalar:Min(ushort,ushort):ushort
-						;; bbWeight=1    PerfScore 1.50
-G_M41244_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 16, prolog size 3, PerfScore 5.85, (MethodHash=779f5ee3) for method JITTest.ScalarUShort:Min(ushort,ushort):ushort
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(ushort,ushort):ushort
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )  ushort  ->  ecx        
-;  V01 arg1         [V01,T01] (  3,  3   )  ushort  ->  edx        
-;  V02 tmp0         [V02,T04] (  3,  2   )  ushort  ->  edx         "Inline return value spill temp"
-;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
-;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
-;
-; Lcl frame size = 0
-
-G_M4923_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M4923_IG02:
        movzx    eax, cx
        movzx    edx, dx
        cmp      eax, edx
-       jle      SHORT G_M4923_IG04
+       jle      SHORT G_M41244_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M4923_IG03:
-       jmp      SHORT G_M4923_IG05
+G_M41244_IG03:
+       jmp      SHORT G_M41244_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M4923_IG04:
+G_M41244_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M4923_IG05:
+G_M41244_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M4923_IG06:
+G_M41244_IG06:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=35e3ecc4) for method Silk.NET.Maths.Scalar:Min(ushort,ushort):ushort
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=779f5ee3) for method JITTest.ScalarUShort:Min(ushort,ushort):ushort
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUShort:Max(ushort,ushort):ushort
@@ -3769,6 +3744,10 @@ G_M4923_IG06:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )  ushort  ->  ecx        
 ;  V01 arg1         [V01,T01] (  3,  3   )  ushort  ->  edx        
+;* V02 tmp0         [V02    ] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T04] (  3,  2   )  ushort  ->  edx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
@@ -3777,58 +3756,26 @@ G_M41986_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M41986_IG02:
-       movzx    ecx, cx
-       movzx    edx, dx
-       call     Silk.NET.Maths.Scalar:Max(ushort,ushort):ushort
-						;; bbWeight=1    PerfScore 1.50
-G_M41986_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 16, prolog size 3, PerfScore 5.85, (MethodHash=76385bfd) for method JITTest.ScalarUShort:Max(ushort,ushort):ushort
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(ushort,ushort):ushort
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )  ushort  ->  ecx        
-;  V01 arg1         [V01,T01] (  3,  3   )  ushort  ->  edx        
-;  V02 tmp0         [V02,T04] (  3,  2   )  ushort  ->  edx         "Inline return value spill temp"
-;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
-;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
-;
-; Lcl frame size = 0
-
-G_M805_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M805_IG02:
        movzx    eax, cx
        movzx    edx, dx
        cmp      eax, edx
-       jge      SHORT G_M805_IG04
+       jge      SHORT G_M41986_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M805_IG03:
-       jmp      SHORT G_M805_IG05
+G_M41986_IG03:
+       jmp      SHORT G_M41986_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M805_IG04:
+G_M41986_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M805_IG05:
+G_M41986_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M805_IG06:
+G_M41986_IG06:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=c73bfcda) for method Silk.NET.Maths.Scalar:Max(ushort,ushort):ushort
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=76385bfd) for method JITTest.ScalarUShort:Max(ushort,ushort):ushort
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUShort:Larger(ushort,ushort):bool
@@ -3997,7 +3944,7 @@ G_M59470_IG03:
 ; Total bytes of code 36, prolog size 4, PerfScore 13.10, (MethodHash=7db317b1) for method JITTest.ScalarUShort:Clamp(ushort,ushort,ushort):ushort
 ; ============================================================
 
-; Assembly listing for method JITTest.ScalarUShort:Negate(ushort):ushort
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(ushort,ushort):ushort
 ; Emitting BLENDED_CODE for generic X86 CPU - Windows
 ; optimized code
 ; ebp based frame
@@ -4005,6 +3952,92 @@ G_M59470_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )  ushort  ->  ecx        
+;  V01 arg1         [V01,T01] (  3,  3   )  ushort  ->  edx        
+;  V02 tmp0         [V02,T04] (  3,  2   )  ushort  ->  edx         "Inline return value spill temp"
+;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M805_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M805_IG02:
+       movzx    eax, cx
+       movzx    edx, dx
+       cmp      eax, edx
+       jge      SHORT G_M805_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M805_IG03:
+       jmp      SHORT G_M805_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M805_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M805_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M805_IG06:
+       pop      ebp
+       ret      
+						;; bbWeight=1    PerfScore 1.50
+
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=c73bfcda) for method Silk.NET.Maths.Scalar:Max(ushort,ushort):ushort
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(ushort,ushort):ushort
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  3,  3   )  ushort  ->  ecx        
+;  V01 arg1         [V01,T01] (  3,  3   )  ushort  ->  edx        
+;  V02 tmp0         [V02,T04] (  3,  2   )  ushort  ->  edx         "Inline return value spill temp"
+;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M4923_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M4923_IG02:
+       movzx    eax, cx
+       movzx    edx, dx
+       cmp      eax, edx
+       jle      SHORT G_M4923_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M4923_IG03:
+       jmp      SHORT G_M4923_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M4923_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M4923_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M4923_IG06:
+       pop      ebp
+       ret      
+						;; bbWeight=1    PerfScore 1.50
+
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=35e3ecc4) for method Silk.NET.Maths.Scalar:Min(ushort,ushort):ushort
+; ============================================================
+
+; Assembly listing for method JITTest.ScalarUShort:Negate(ushort):ushort
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;* V00 arg0         [V00    ] (  0,  0   )  ushort  ->  zero-ref   
+;* V01 tmp0         [V01    ] (  0,  0   )  ushort  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )  ushort  ->  zero-ref    ld-addr-op "Inline ldloca(s) first use temp"
 ;
 ; Lcl frame size = 0
 
@@ -4013,39 +4046,11 @@ G_M52289_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M52289_IG02:
-       movzx    ecx, cx
-       call     Silk.NET.Maths.Scalar:Negate(ushort):ushort
-						;; bbWeight=1    PerfScore 1.25
-G_M52289_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 13, prolog size 3, PerfScore 5.30, (MethodHash=358e33be) for method JITTest.ScalarUShort:Negate(ushort):ushort
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(ushort):ushort
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;* V00 arg0         [V00    ] (  0,  0   )  ushort  ->  zero-ref   
-;* V01 loc0         [V01    ] (  0,  0   )  ushort  ->  zero-ref    ld-addr-op
-;
-; Lcl frame size = 0
-
-G_M11110_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M11110_IG02:
        call     Silk.NET.Maths.Scalar:ThrowInvalidType()
        int3     
 						;; bbWeight=0    PerfScore 0.00
 
-; Total bytes of code 9, prolog size 3, PerfScore 2.15, (MethodHash=ec21d499) for method Silk.NET.Maths.Scalar:Negate(ushort):ushort
+; Total bytes of code 9, prolog size 3, PerfScore 2.15, (MethodHash=358e33be) for method JITTest.ScalarUShort:Negate(ushort):ushort
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUShort:Equal(ushort,ushort):bool
@@ -4653,7 +4658,7 @@ G_M63071_IG02:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;* V00 tmp0         [V00,T00] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -4679,7 +4684,7 @@ G_M34686_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;* V00 tmp0         [V00,T00] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -4706,7 +4711,7 @@ G_M42262_IG03:
 ; Final local variable assignments
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )   short  ->  zero-ref   
-;* V01 tmp0         [V01,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -5073,6 +5078,10 @@ G_M17157_IG03:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  ecx        
 ;  V01 arg1         [V01,T01] (  3,  3   )   short  ->  edx        
+;* V02 tmp0         [V02    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T04] (  3,  2   )   short  ->  edx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
@@ -5081,58 +5090,26 @@ G_M55292_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M55292_IG02:
-       movsx    ecx, cx
-       movsx    edx, dx
-       call     Silk.NET.Maths.Scalar:Min(short,short):short
-						;; bbWeight=1    PerfScore 1.50
-G_M55292_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 16, prolog size 3, PerfScore 5.85, (MethodHash=7a272803) for method JITTest.ScalarShort:Min(short,short):short
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(short,short):short
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  ecx        
-;  V01 arg1         [V01,T01] (  3,  3   )   short  ->  edx        
-;  V02 tmp0         [V02,T04] (  3,  2   )   short  ->  edx         "Inline return value spill temp"
-;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
-;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
-;
-; Lcl frame size = 0
-
-G_M12462_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M12462_IG02:
        movsx    eax, cx
        movsx    edx, dx
        cmp      eax, edx
-       jle      SHORT G_M12462_IG04
+       jle      SHORT G_M55292_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M12462_IG03:
-       jmp      SHORT G_M12462_IG05
+G_M55292_IG03:
+       jmp      SHORT G_M55292_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M12462_IG04:
+G_M55292_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M12462_IG05:
+G_M55292_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M12462_IG06:
+G_M55292_IG06:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=d86dcf51) for method Silk.NET.Maths.Scalar:Min(short,short):short
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=7a272803) for method JITTest.ScalarShort:Min(short,short):short
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarShort:Max(short,short):short
@@ -5144,6 +5121,10 @@ G_M12462_IG06:
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  ecx        
 ;  V01 arg1         [V01,T01] (  3,  3   )   short  ->  edx        
+;* V02 tmp0         [V02    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T04] (  3,  2   )   short  ->  edx         "Inline return value spill temp"
+;  V04 cse0         [V04,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V05 cse1         [V05,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
 ;
 ; Lcl frame size = 0
 
@@ -5152,58 +5133,26 @@ G_M6306_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M6306_IG02:
-       movsx    ecx, cx
-       movsx    edx, dx
-       call     Silk.NET.Maths.Scalar:Max(short,short):short
-						;; bbWeight=1    PerfScore 1.50
-G_M6306_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 16, prolog size 3, PerfScore 5.85, (MethodHash=fcfbe75d) for method JITTest.ScalarShort:Max(short,short):short
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(short,short):short
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  ecx        
-;  V01 arg1         [V01,T01] (  3,  3   )   short  ->  edx        
-;  V02 tmp0         [V02,T04] (  3,  2   )   short  ->  edx         "Inline return value spill temp"
-;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
-;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
-;
-; Lcl frame size = 0
-
-G_M2800_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M2800_IG02:
        movsx    eax, cx
        movsx    edx, dx
        cmp      eax, edx
-       jge      SHORT G_M2800_IG04
+       jge      SHORT G_M6306_IG04
 						;; bbWeight=1    PerfScore 1.75
-G_M2800_IG03:
-       jmp      SHORT G_M2800_IG05
+G_M6306_IG03:
+       jmp      SHORT G_M6306_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M2800_IG04:
+G_M6306_IG04:
        mov      edx, eax
 						;; bbWeight=0.50 PerfScore 0.12
-G_M2800_IG05:
+G_M6306_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M2800_IG06:
+G_M6306_IG06:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=175cf50f) for method Silk.NET.Maths.Scalar:Max(short,short):short
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=fcfbe75d) for method JITTest.ScalarShort:Max(short,short):short
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarShort:Larger(short,short):bool
@@ -5372,6 +5321,90 @@ G_M23835_IG03:
 ; Total bytes of code 36, prolog size 4, PerfScore 13.10, (MethodHash=0856a2e4) for method JITTest.ScalarShort:Clamp(short,short,short):short
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(short,short):short
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  ecx        
+;  V01 arg1         [V01,T01] (  3,  3   )   short  ->  edx        
+;  V02 tmp0         [V02,T04] (  3,  2   )   short  ->  edx         "Inline return value spill temp"
+;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M2800_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M2800_IG02:
+       movsx    eax, cx
+       movsx    edx, dx
+       cmp      eax, edx
+       jge      SHORT G_M2800_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M2800_IG03:
+       jmp      SHORT G_M2800_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M2800_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M2800_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M2800_IG06:
+       pop      ebp
+       ret      
+						;; bbWeight=1    PerfScore 1.50
+
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=175cf50f) for method Silk.NET.Maths.Scalar:Max(short,short):short
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(short,short):short
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  ecx        
+;  V01 arg1         [V01,T01] (  3,  3   )   short  ->  edx        
+;  V02 tmp0         [V02,T04] (  3,  2   )   short  ->  edx         "Inline return value spill temp"
+;  V03 cse0         [V03,T02] (  3,  2.50)     int  ->  edx         "CSE - aggressive"
+;  V04 cse1         [V04,T03] (  3,  2.50)     int  ->  eax         "CSE - aggressive"
+;
+; Lcl frame size = 0
+
+G_M12462_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M12462_IG02:
+       movsx    eax, cx
+       movsx    edx, dx
+       cmp      eax, edx
+       jle      SHORT G_M12462_IG04
+						;; bbWeight=1    PerfScore 1.75
+G_M12462_IG03:
+       jmp      SHORT G_M12462_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M12462_IG04:
+       mov      edx, eax
+						;; bbWeight=0.50 PerfScore 0.12
+G_M12462_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M12462_IG06:
+       pop      ebp
+       ret      
+						;; bbWeight=1    PerfScore 1.50
+
+; Total bytes of code 21, prolog size 3, PerfScore 7.98, (MethodHash=d86dcf51) for method Silk.NET.Maths.Scalar:Min(short,short):short
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarShort:Negate(short):short
 ; Emitting BLENDED_CODE for generic X86 CPU - Windows
 ; optimized code
@@ -5380,6 +5413,7 @@ G_M23835_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  ecx        
+;  V01 tmp0         [V01,T01] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -5388,44 +5422,16 @@ G_M59732_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M59732_IG02:
-       movsx    ecx, cx
-       call     Silk.NET.Maths.Scalar:Negate(short):short
-						;; bbWeight=1    PerfScore 1.25
+       movsx    eax, cx
+       neg      eax
+       movsx    eax, ax
+						;; bbWeight=1    PerfScore 0.75
 G_M59732_IG03:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 13, prolog size 3, PerfScore 5.30, (MethodHash=8d9016ab) for method JITTest.ScalarShort:Negate(short):short
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(short):short
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )   short  ->  ecx        
-;* V01 loc0         [V01    ] (  0,  0   )   short  ->  zero-ref    ld-addr-op
-;
-; Lcl frame size = 0
-
-G_M38726_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M38726_IG02:
-       movsx    eax, cx
-       neg      eax
-       movsx    eax, ax
-						;; bbWeight=1    PerfScore 0.75
-G_M38726_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 13, prolog size 3, PerfScore 4.80, (MethodHash=517c68b9) for method Silk.NET.Maths.Scalar:Negate(short):short
+; Total bytes of code 13, prolog size 3, PerfScore 4.80, (MethodHash=8d9016ab) for method JITTest.ScalarShort:Negate(short):short
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarShort:Equal(short,short):bool
@@ -6096,7 +6102,7 @@ G_M7874_IG03:
 ; Final local variable assignments
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )     int  ->  zero-ref   
-;* V01 tmp0         [V01,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -6467,8 +6473,10 @@ G_M53713_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  ecx        
-;  V01 arg1         [V01,T01] (  3,  3   )     int  ->  edx        
+;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  ecx        
+;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  edx        
+;* V02 tmp0         [V02    ] (  0,  0   )     int  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T02] (  3,  2   )     int  ->  edx         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -6477,52 +6485,24 @@ G_M14664_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M14664_IG02:
-       call     Silk.NET.Maths.Scalar:Min(int,int):int
-						;; bbWeight=1    PerfScore 1.00
-G_M14664_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 10, prolog size 3, PerfScore 4.75, (MethodHash=236fc6b7) for method JITTest.ScalarUInt32:Min(int,int):int
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(int,int):int
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  ecx        
-;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  edx        
-;  V02 tmp0         [V02,T02] (  3,  2   )     int  ->  edx         "Inline return value spill temp"
-;
-; Lcl frame size = 0
-
-G_M22191_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M22191_IG02:
        cmp      ecx, edx
-       jbe      SHORT G_M22191_IG04
+       jbe      SHORT G_M14664_IG04
 						;; bbWeight=1    PerfScore 1.25
-G_M22191_IG03:
-       jmp      SHORT G_M22191_IG05
+G_M14664_IG03:
+       jmp      SHORT G_M14664_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M22191_IG04:
+G_M14664_IG04:
        mov      edx, ecx
 						;; bbWeight=0.50 PerfScore 0.12
-G_M22191_IG05:
+G_M14664_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M22191_IG06:
+G_M14664_IG06:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 15, prolog size 3, PerfScore 6.88, (MethodHash=1a40a950) for method Silk.NET.Maths.Scalar:Min(int,int):int
+; Total bytes of code 15, prolog size 3, PerfScore 6.88, (MethodHash=236fc6b7) for method JITTest.ScalarUInt32:Min(int,int):int
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUInt32:Max(int,int):int
@@ -6532,8 +6512,10 @@ G_M22191_IG06:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  ecx        
-;  V01 arg1         [V01,T01] (  3,  3   )     int  ->  edx        
+;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  ecx        
+;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  edx        
+;* V02 tmp0         [V02    ] (  0,  0   )     int  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T02] (  3,  2   )     int  ->  edx         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -6542,52 +6524,24 @@ G_M14102_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M14102_IG02:
-       call     Silk.NET.Maths.Scalar:Max(int,int):int
-						;; bbWeight=1    PerfScore 1.00
-G_M14102_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 10, prolog size 3, PerfScore 4.75, (MethodHash=7fd8c8e9) for method JITTest.ScalarUInt32:Max(int,int):int
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(int,int):int
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  ecx        
-;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  edx        
-;  V02 tmp0         [V02,T02] (  3,  2   )     int  ->  edx         "Inline return value spill temp"
-;
-; Lcl frame size = 0
-
-G_M5361_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M5361_IG02:
        cmp      ecx, edx
-       jae      SHORT G_M5361_IG04
+       jae      SHORT G_M14102_IG04
 						;; bbWeight=1    PerfScore 1.25
-G_M5361_IG03:
-       jmp      SHORT G_M5361_IG05
+G_M14102_IG03:
+       jmp      SHORT G_M14102_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M5361_IG04:
+G_M14102_IG04:
        mov      edx, ecx
 						;; bbWeight=0.50 PerfScore 0.12
-G_M5361_IG05:
+G_M14102_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M5361_IG06:
+G_M14102_IG06:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 15, prolog size 3, PerfScore 6.88, (MethodHash=223aeb0e) for method Silk.NET.Maths.Scalar:Max(int,int):int
+; Total bytes of code 15, prolog size 3, PerfScore 6.88, (MethodHash=7fd8c8e9) for method JITTest.ScalarUInt32:Max(int,int):int
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUInt32:Larger(int,int):bool
@@ -6742,6 +6696,82 @@ G_M59214_IG03:
 ; Total bytes of code 22, prolog size 3, PerfScore 9.20, (MethodHash=af4b18b1) for method JITTest.ScalarUInt32:Clamp(int,int,int):int
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(int,int):int
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  ecx        
+;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  edx        
+;  V02 tmp0         [V02,T02] (  3,  2   )     int  ->  edx         "Inline return value spill temp"
+;
+; Lcl frame size = 0
+
+G_M5361_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M5361_IG02:
+       cmp      ecx, edx
+       jae      SHORT G_M5361_IG04
+						;; bbWeight=1    PerfScore 1.25
+G_M5361_IG03:
+       jmp      SHORT G_M5361_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M5361_IG04:
+       mov      edx, ecx
+						;; bbWeight=0.50 PerfScore 0.12
+G_M5361_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M5361_IG06:
+       pop      ebp
+       ret      
+						;; bbWeight=1    PerfScore 1.50
+
+; Total bytes of code 15, prolog size 3, PerfScore 6.88, (MethodHash=223aeb0e) for method Silk.NET.Maths.Scalar:Max(int,int):int
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(int,int):int
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  ecx        
+;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  edx        
+;  V02 tmp0         [V02,T02] (  3,  2   )     int  ->  edx         "Inline return value spill temp"
+;
+; Lcl frame size = 0
+
+G_M22191_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M22191_IG02:
+       cmp      ecx, edx
+       jbe      SHORT G_M22191_IG04
+						;; bbWeight=1    PerfScore 1.25
+G_M22191_IG03:
+       jmp      SHORT G_M22191_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M22191_IG04:
+       mov      edx, ecx
+						;; bbWeight=0.50 PerfScore 0.12
+G_M22191_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M22191_IG06:
+       pop      ebp
+       ret      
+						;; bbWeight=1    PerfScore 1.50
+
+; Total bytes of code 15, prolog size 3, PerfScore 6.88, (MethodHash=1a40a950) for method Silk.NET.Maths.Scalar:Min(int,int):int
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarUInt32:Negate(int):int
 ; Emitting BLENDED_CODE for generic X86 CPU - Windows
 ; optimized code
@@ -6749,7 +6779,9 @@ G_M59214_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  ecx        
+;* V00 arg0         [V00    ] (  0,  0   )     int  ->  zero-ref   
+;* V01 tmp0         [V01    ] (  0,  0   )     int  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )     int  ->  zero-ref    ld-addr-op "Inline ldloca(s) first use temp"
 ;
 ; Lcl frame size = 0
 
@@ -6758,38 +6790,11 @@ G_M16865_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M16865_IG02:
-       call     Silk.NET.Maths.Scalar:Negate(int):int
-						;; bbWeight=1    PerfScore 1.00
-G_M16865_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 10, prolog size 3, PerfScore 4.75, (MethodHash=9890be1e) for method JITTest.ScalarUInt32:Negate(int):int
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(int):int
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;* V00 arg0         [V00    ] (  0,  0   )     int  ->  zero-ref   
-;* V01 loc0         [V01    ] (  0,  0   )     int  ->  zero-ref    ld-addr-op
-;
-; Lcl frame size = 0
-
-G_M7398_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M7398_IG02:
        call     Silk.NET.Maths.Scalar:ThrowInvalidType()
        int3     
 						;; bbWeight=0    PerfScore 0.00
 
-; Total bytes of code 9, prolog size 3, PerfScore 2.15, (MethodHash=4620e319) for method Silk.NET.Maths.Scalar:Negate(int):int
+; Total bytes of code 9, prolog size 3, PerfScore 2.15, (MethodHash=9890be1e) for method JITTest.ScalarUInt32:Negate(int):int
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUInt32:Equal(int,int):bool
@@ -7448,7 +7453,7 @@ G_M44407_IG03:
 ; Final local variable assignments
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )     int  ->  zero-ref   
-;* V01 tmp0         [V01,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -7806,8 +7811,10 @@ G_M45924_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  ecx        
-;  V01 arg1         [V01,T01] (  3,  3   )     int  ->  edx        
+;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  ecx        
+;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  edx        
+;* V02 tmp0         [V02    ] (  0,  0   )     int  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T02] (  3,  2   )     int  ->  edx         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -7816,52 +7823,24 @@ G_M18973_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M18973_IG02:
-       call     Silk.NET.Maths.Scalar:Min(int,int):int
-						;; bbWeight=1    PerfScore 1.00
-G_M18973_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 10, prolog size 3, PerfScore 4.75, (MethodHash=0d39b5e2) for method JITTest.ScalarInt32:Min(int,int):int
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(int,int):int
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  ecx        
-;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  edx        
-;  V02 tmp0         [V02,T02] (  3,  2   )     int  ->  edx         "Inline return value spill temp"
-;
-; Lcl frame size = 0
-
-G_M22191_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M22191_IG02:
        cmp      ecx, edx
-       jle      SHORT G_M22191_IG04
+       jle      SHORT G_M18973_IG04
 						;; bbWeight=1    PerfScore 1.25
-G_M22191_IG03:
-       jmp      SHORT G_M22191_IG05
+G_M18973_IG03:
+       jmp      SHORT G_M18973_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M22191_IG04:
+G_M18973_IG04:
        mov      edx, ecx
 						;; bbWeight=0.50 PerfScore 0.12
-G_M22191_IG05:
+G_M18973_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M22191_IG06:
+G_M18973_IG06:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 15, prolog size 3, PerfScore 6.88, (MethodHash=1a40a950) for method Silk.NET.Maths.Scalar:Min(int,int):int
+; Total bytes of code 15, prolog size 3, PerfScore 6.88, (MethodHash=0d39b5e2) for method JITTest.ScalarInt32:Min(int,int):int
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarInt32:Max(int,int):int
@@ -7871,8 +7850,10 @@ G_M22191_IG06:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  ecx        
-;  V01 arg1         [V01,T01] (  3,  3   )     int  ->  edx        
+;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  ecx        
+;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  edx        
+;* V02 tmp0         [V02    ] (  0,  0   )     int  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T02] (  3,  2   )     int  ->  edx         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -7881,52 +7862,24 @@ G_M35779_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M35779_IG02:
-       call     Silk.NET.Maths.Scalar:Max(int,int):int
-						;; bbWeight=1    PerfScore 1.00
-G_M35779_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 10, prolog size 3, PerfScore 4.75, (MethodHash=428a743c) for method JITTest.ScalarInt32:Max(int,int):int
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(int,int):int
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  ecx        
-;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  edx        
-;  V02 tmp0         [V02,T02] (  3,  2   )     int  ->  edx         "Inline return value spill temp"
-;
-; Lcl frame size = 0
-
-G_M5361_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M5361_IG02:
        cmp      ecx, edx
-       jge      SHORT G_M5361_IG04
+       jge      SHORT G_M35779_IG04
 						;; bbWeight=1    PerfScore 1.25
-G_M5361_IG03:
-       jmp      SHORT G_M5361_IG05
+G_M35779_IG03:
+       jmp      SHORT G_M35779_IG05
 						;; bbWeight=0.50 PerfScore 1.00
-G_M5361_IG04:
+G_M35779_IG04:
        mov      edx, ecx
 						;; bbWeight=0.50 PerfScore 0.12
-G_M5361_IG05:
+G_M35779_IG05:
        mov      eax, edx
 						;; bbWeight=1    PerfScore 0.25
-G_M5361_IG06:
+G_M35779_IG06:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 15, prolog size 3, PerfScore 6.88, (MethodHash=223aeb0e) for method Silk.NET.Maths.Scalar:Max(int,int):int
+; Total bytes of code 15, prolog size 3, PerfScore 6.88, (MethodHash=428a743c) for method JITTest.ScalarInt32:Max(int,int):int
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarInt32:Larger(int,int):bool
@@ -8081,6 +8034,82 @@ G_M27291_IG03:
 ; Total bytes of code 22, prolog size 3, PerfScore 9.20, (MethodHash=1ffd9564) for method JITTest.ScalarInt32:Clamp(int,int,int):int
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(int,int):int
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  ecx        
+;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  edx        
+;  V02 tmp0         [V02,T02] (  3,  2   )     int  ->  edx         "Inline return value spill temp"
+;
+; Lcl frame size = 0
+
+G_M5361_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M5361_IG02:
+       cmp      ecx, edx
+       jge      SHORT G_M5361_IG04
+						;; bbWeight=1    PerfScore 1.25
+G_M5361_IG03:
+       jmp      SHORT G_M5361_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M5361_IG04:
+       mov      edx, ecx
+						;; bbWeight=0.50 PerfScore 0.12
+G_M5361_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M5361_IG06:
+       pop      ebp
+       ret      
+						;; bbWeight=1    PerfScore 1.50
+
+; Total bytes of code 15, prolog size 3, PerfScore 6.88, (MethodHash=223aeb0e) for method Silk.NET.Maths.Scalar:Max(int,int):int
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(int,int):int
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T00] (  4,  3.50)     int  ->  ecx        
+;  V01 arg1         [V01,T01] (  4,  3.50)     int  ->  edx        
+;  V02 tmp0         [V02,T02] (  3,  2   )     int  ->  edx         "Inline return value spill temp"
+;
+; Lcl frame size = 0
+
+G_M22191_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M22191_IG02:
+       cmp      ecx, edx
+       jle      SHORT G_M22191_IG04
+						;; bbWeight=1    PerfScore 1.25
+G_M22191_IG03:
+       jmp      SHORT G_M22191_IG05
+						;; bbWeight=0.50 PerfScore 1.00
+G_M22191_IG04:
+       mov      edx, ecx
+						;; bbWeight=0.50 PerfScore 0.12
+G_M22191_IG05:
+       mov      eax, edx
+						;; bbWeight=1    PerfScore 0.25
+G_M22191_IG06:
+       pop      ebp
+       ret      
+						;; bbWeight=1    PerfScore 1.50
+
+; Total bytes of code 15, prolog size 3, PerfScore 6.88, (MethodHash=1a40a950) for method Silk.NET.Maths.Scalar:Min(int,int):int
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarInt32:Negate(int):int
 ; Emitting BLENDED_CODE for generic X86 CPU - Windows
 ; optimized code
@@ -8089,6 +8118,7 @@ G_M27291_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  ecx        
+;  V01 tmp0         [V01,T01] (  2,  2   )     int  ->  eax         "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -8097,42 +8127,15 @@ G_M44628_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M44628_IG02:
-       call     Silk.NET.Maths.Scalar:Negate(int):int
-						;; bbWeight=1    PerfScore 1.00
+       mov      eax, ecx
+       neg      eax
+						;; bbWeight=1    PerfScore 0.50
 G_M44628_IG03:
        pop      ebp
        ret      
 						;; bbWeight=1    PerfScore 1.50
 
-; Total bytes of code 10, prolog size 3, PerfScore 4.75, (MethodHash=605651ab) for method JITTest.ScalarInt32:Negate(int):int
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(int):int
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  3,  3   )     int  ->  ecx        
-;* V01 loc0         [V01    ] (  0,  0   )     int  ->  zero-ref    ld-addr-op
-;
-; Lcl frame size = 0
-
-G_M7398_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M7398_IG02:
-       mov      eax, ecx
-       neg      eax
-						;; bbWeight=1    PerfScore 0.50
-G_M7398_IG03:
-       pop      ebp
-       ret      
-						;; bbWeight=1    PerfScore 1.50
-
-; Total bytes of code 9, prolog size 3, PerfScore 4.15, (MethodHash=4620e319) for method Silk.NET.Maths.Scalar:Negate(int):int
+; Total bytes of code 9, prolog size 3, PerfScore 4.15, (MethodHash=605651ab) for method JITTest.ScalarInt32:Negate(int):int
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarInt32:Equal(int,int):bool
@@ -8859,7 +8862,7 @@ G_M54136_IG03:
 ; Final local variable assignments
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )    long  ->  zero-ref   
-;* V01 tmp0         [V01,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -9061,8 +9064,8 @@ G_M17395_IG03:
 ;  V00 arg0         [V00    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V01 tmp0         [V01    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V02 tmp1         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V03 rat0         [V03    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V04 rat1         [V04    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V03 rat0         [V03,T03] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V04 rat1         [V04,T04] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
 ;* V05 rat2         [V05    ] (  0,  0   )     int  ->  zero-ref    V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
 ;* V06 rat3         [V06    ] (  0,  0   )     int  ->  zero-ref    V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;  V07 rat4         [V07,T01] (  2,  2   )     int  ->  eax         V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
@@ -9113,10 +9116,10 @@ G_M21145_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T02] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T03] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T04] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T05] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
 ;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
 ;  V10 rat6         [V10,T00] (  2,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
@@ -9153,10 +9156,10 @@ G_M21625_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T03] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T04] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T05] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T06] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
 ;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
 ;  V10 rat6         [V10,T01] (  2,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
@@ -9201,10 +9204,10 @@ G_M65374_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T02] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T03] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T04] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T05] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
 ;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
 ;  V10 rat6         [V10,T00] (  2,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
@@ -9241,10 +9244,10 @@ G_M40140_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T03] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T04] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T05] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T06] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
 ;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
 ;  V10 rat6         [V10,T01] (  2,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
@@ -9289,10 +9292,10 @@ G_M22420_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T03] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T04] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T05] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T06] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
 ;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
 ;  V10 rat6         [V10,T01] (  2,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
@@ -9333,89 +9336,50 @@ G_M39755_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00    ] (  2,  2   )    long  ->  [ebp+0x10]  
-;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
-;  V02 rat0         [V02    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V03 rat1         [V03    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V04 rat2         [V04    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V05 rat3         [V05    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
-;  V06 rat4         [V06,T00] (  3,  6   )    long  ->  [ebp-0x08]   multireg-ret "ReplaceWithLclVar is creating a new local variable"
-;
-; Lcl frame size = 8
-
-G_M65298_IG01:
-       push     ebp
-       mov      ebp, esp
-       sub      esp, 8
-						;; bbWeight=1    PerfScore 1.50
-G_M65298_IG02:
-       push     dword ptr [ebp+14H]
-       push     dword ptr [ebp+10H]
-       push     dword ptr [ebp+0CH]
-       push     dword ptr [ebp+08H]
-       call     Silk.NET.Maths.Scalar:Min(long,long):long
-       mov      dword ptr [ebp-08H], eax
-       mov      dword ptr [ebp-04H], edx
-       mov      eax, dword ptr [ebp-08H]
-       mov      edx, dword ptr [ebp-04H]
-						;; bbWeight=1    PerfScore 9.00
-G_M65298_IG03:
-       mov      esp, ebp
-       pop      ebp
-       ret      16
-						;; bbWeight=1    PerfScore 2.75
-
-; Total bytes of code 41, prolog size 6, PerfScore 17.35, (MethodHash=accc00ed) for method JITTest.ScalarUInt64:Min(long,long):long
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(long,long):long
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00    ] (  4,  3   )    long  ->  [ebp+0x10]  
 ;  V01 arg1         [V01    ] (  4,  3   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  2,  1.50)     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  2,  1.50)     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  2,  1.50)     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  2,  1.50)     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
-;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
-;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
-;  V10 rat6         [V10,T00] (  3,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
-;  V11 rat7         [V11,T01] (  3,  2   )     int  ->  edx         V03.hi(offs=0x04) "field V03.hi (fldOffset=0x4)"
+;* V04 tmp2         [V04    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V05 rat0         [V05,T02] (  2,  1.50)     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V06 rat1         [V06,T03] (  2,  1.50)     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V07 rat2         [V07,T04] (  2,  1.50)     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V08 rat3         [V08,T05] (  2,  1.50)     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;* V09 rat4         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
+;* V10 rat5         [V10    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
+;* V11 rat6         [V11    ] (  0,  0   )     int  ->  zero-ref    V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
+;* V12 rat7         [V12    ] (  0,  0   )     int  ->  zero-ref    V03.hi(offs=0x04) "field V03.hi (fldOffset=0x4)"
+;  V13 rat8         [V13,T00] (  3,  2   )     int  ->  eax         V04.lo(offs=0x00) "field V04.lo (fldOffset=0x0)"
+;  V14 rat9         [V14,T01] (  3,  2   )     int  ->  edx         V04.hi(offs=0x04) "field V04.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
-G_M34166_IG01:
+G_M65298_IG01:
        push     ebp
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
-G_M34166_IG02:
+G_M65298_IG02:
        mov      eax, dword ptr [ebp+08H]
        cmp      eax, dword ptr [ebp+10H]
        mov      eax, dword ptr [ebp+0CH]
        sbb      eax, dword ptr [ebp+14H]
-       jae      SHORT G_M34166_IG04
+       jae      SHORT G_M65298_IG04
 						;; bbWeight=1    PerfScore 5.00
-G_M34166_IG03:
+G_M65298_IG03:
        mov      eax, dword ptr [ebp+08H]
        mov      edx, dword ptr [ebp+0CH]
-       jmp      SHORT G_M34166_IG05
+       jmp      SHORT G_M65298_IG05
 						;; bbWeight=0.50 PerfScore 2.00
-G_M34166_IG04:
+G_M65298_IG04:
        mov      eax, dword ptr [ebp+10H]
        mov      edx, dword ptr [ebp+14H]
 						;; bbWeight=0.50 PerfScore 1.00
-G_M34166_IG05:
+G_M65298_IG05:
        pop      ebp
        ret      16
 						;; bbWeight=1    PerfScore 2.50
 
-; Total bytes of code 35, prolog size 3, PerfScore 15.25, (MethodHash=02627a89) for method Silk.NET.Maths.Scalar:Min(long,long):long
+; Total bytes of code 35, prolog size 3, PerfScore 15.25, (MethodHash=accc00ed) for method JITTest.ScalarUInt64:Min(long,long):long
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUInt64:Max(long,long):long
@@ -9425,89 +9389,50 @@ G_M34166_IG05:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00    ] (  2,  2   )    long  ->  [ebp+0x10]  
-;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
-;  V02 rat0         [V02    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V03 rat1         [V03    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V04 rat2         [V04    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V05 rat3         [V05    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
-;  V06 rat4         [V06,T00] (  3,  6   )    long  ->  [ebp-0x08]   multireg-ret "ReplaceWithLclVar is creating a new local variable"
-;
-; Lcl frame size = 8
-
-G_M36620_IG01:
-       push     ebp
-       mov      ebp, esp
-       sub      esp, 8
-						;; bbWeight=1    PerfScore 1.50
-G_M36620_IG02:
-       push     dword ptr [ebp+14H]
-       push     dword ptr [ebp+10H]
-       push     dword ptr [ebp+0CH]
-       push     dword ptr [ebp+08H]
-       call     Silk.NET.Maths.Scalar:Max(long,long):long
-       mov      dword ptr [ebp-08H], eax
-       mov      dword ptr [ebp-04H], edx
-       mov      eax, dword ptr [ebp-08H]
-       mov      edx, dword ptr [ebp-04H]
-						;; bbWeight=1    PerfScore 9.00
-G_M36620_IG03:
-       mov      esp, ebp
-       pop      ebp
-       ret      16
-						;; bbWeight=1    PerfScore 2.75
-
-; Total bytes of code 41, prolog size 6, PerfScore 17.35, (MethodHash=a97970f3) for method JITTest.ScalarUInt64:Max(long,long):long
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(long,long):long
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00    ] (  4,  3   )    long  ->  [ebp+0x10]  
 ;  V01 arg1         [V01    ] (  4,  3   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  2,  1.50)     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  2,  1.50)     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  2,  1.50)     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  2,  1.50)     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
-;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
-;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
-;  V10 rat6         [V10,T00] (  3,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
-;  V11 rat7         [V11,T01] (  3,  2   )     int  ->  edx         V03.hi(offs=0x04) "field V03.hi (fldOffset=0x4)"
+;* V04 tmp2         [V04    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V05 rat0         [V05,T02] (  2,  1.50)     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V06 rat1         [V06,T03] (  2,  1.50)     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V07 rat2         [V07,T04] (  2,  1.50)     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V08 rat3         [V08,T05] (  2,  1.50)     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;* V09 rat4         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
+;* V10 rat5         [V10    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
+;* V11 rat6         [V11    ] (  0,  0   )     int  ->  zero-ref    V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
+;* V12 rat7         [V12    ] (  0,  0   )     int  ->  zero-ref    V03.hi(offs=0x04) "field V03.hi (fldOffset=0x4)"
+;  V13 rat8         [V13,T00] (  3,  2   )     int  ->  eax         V04.lo(offs=0x00) "field V04.lo (fldOffset=0x0)"
+;  V14 rat9         [V14,T01] (  3,  2   )     int  ->  edx         V04.hi(offs=0x04) "field V04.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
-G_M54120_IG01:
+G_M36620_IG01:
        push     ebp
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
-G_M54120_IG02:
+G_M36620_IG02:
        mov      eax, dword ptr [ebp+10H]
        cmp      eax, dword ptr [ebp+08H]
        mov      eax, dword ptr [ebp+14H]
        sbb      eax, dword ptr [ebp+0CH]
-       jae      SHORT G_M54120_IG04
+       jae      SHORT G_M36620_IG04
 						;; bbWeight=1    PerfScore 5.00
-G_M54120_IG03:
+G_M36620_IG03:
        mov      eax, dword ptr [ebp+08H]
        mov      edx, dword ptr [ebp+0CH]
-       jmp      SHORT G_M54120_IG05
+       jmp      SHORT G_M36620_IG05
 						;; bbWeight=0.50 PerfScore 2.00
-G_M54120_IG04:
+G_M36620_IG04:
        mov      eax, dword ptr [ebp+10H]
        mov      edx, dword ptr [ebp+14H]
 						;; bbWeight=0.50 PerfScore 1.00
-G_M54120_IG05:
+G_M36620_IG05:
        pop      ebp
        ret      16
 						;; bbWeight=1    PerfScore 2.50
 
-; Total bytes of code 35, prolog size 3, PerfScore 15.25, (MethodHash=79ab2c97) for method Silk.NET.Maths.Scalar:Max(long,long):long
+; Total bytes of code 35, prolog size 3, PerfScore 15.25, (MethodHash=a97970f3) for method JITTest.ScalarUInt64:Max(long,long):long
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUInt64:Larger(long,long):bool
@@ -9521,10 +9446,10 @@ G_M54120_IG05:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;  V03 tmp1         [V03,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T01] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T02] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T03] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T04] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
@@ -9559,10 +9484,10 @@ G_M61715_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;  V03 tmp1         [V03,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T01] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T02] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T03] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T04] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
@@ -9597,10 +9522,10 @@ G_M25428_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;  V03 tmp1         [V03,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T01] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T02] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T03] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T04] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
@@ -9635,10 +9560,10 @@ G_M49708_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;  V03 tmp1         [V03,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T01] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T02] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T03] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T04] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
@@ -9672,12 +9597,12 @@ G_M55851_IG03:
 ;  V00 arg0         [V00    ] (  2,  2   )    long  ->  [ebp+0x18]  
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x10]  
 ;  V02 arg2         [V02    ] (  2,  2   )    long  ->  [ebp+0x08]  
-;  V03 rat0         [V03    ] (  1,  1   )     int  ->  [ebp+0x18]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V04 rat1         [V04    ] (  1,  1   )     int  ->  [ebp+0x1C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V05 rat2         [V05    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V06 rat3         [V06    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
-;  V07 rat4         [V07    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
-;  V08 rat5         [V08    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
+;  V03 rat0         [V03,T02] (  1,  1   )     int  ->  [ebp+0x18]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V04 rat1         [V04,T03] (  1,  1   )     int  ->  [ebp+0x1C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V05 rat2         [V05,T04] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V06 rat3         [V06,T05] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V07 rat4         [V07,T06] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
+;  V08 rat5         [V08,T07] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
 ;  V09 rat6         [V09,T00] (  3,  6   )    long  ->  [ebp-0x08]   multireg-ret "ReplaceWithLclVar is creating a new local variable"
 ;  V10 rat7         [V10,T01] (  3,  6   )    long  ->  [ebp-0x10]   multireg-ret "ReplaceWithLclVar is creating a new local variable"
 ;
@@ -9717,6 +9642,106 @@ G_M21965_IG03:
 ; Total bytes of code 66, prolog size 6, PerfScore 28.85, (MethodHash=8145aa32) for method JITTest.ScalarUInt64:Clamp(long,long,long):long
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(long,long):long
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00    ] (  4,  3   )    long  ->  [ebp+0x10]  
+;  V01 arg1         [V01    ] (  4,  3   )    long  ->  [ebp+0x08]  
+;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V04 rat0         [V04,T02] (  2,  1.50)     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T03] (  2,  1.50)     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T04] (  2,  1.50)     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T05] (  2,  1.50)     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
+;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
+;  V10 rat6         [V10,T00] (  3,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
+;  V11 rat7         [V11,T01] (  3,  2   )     int  ->  edx         V03.hi(offs=0x04) "field V03.hi (fldOffset=0x4)"
+;
+; Lcl frame size = 0
+
+G_M54120_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M54120_IG02:
+       mov      eax, dword ptr [ebp+10H]
+       cmp      eax, dword ptr [ebp+08H]
+       mov      eax, dword ptr [ebp+14H]
+       sbb      eax, dword ptr [ebp+0CH]
+       jae      SHORT G_M54120_IG04
+						;; bbWeight=1    PerfScore 5.00
+G_M54120_IG03:
+       mov      eax, dword ptr [ebp+08H]
+       mov      edx, dword ptr [ebp+0CH]
+       jmp      SHORT G_M54120_IG05
+						;; bbWeight=0.50 PerfScore 2.00
+G_M54120_IG04:
+       mov      eax, dword ptr [ebp+10H]
+       mov      edx, dword ptr [ebp+14H]
+						;; bbWeight=0.50 PerfScore 1.00
+G_M54120_IG05:
+       pop      ebp
+       ret      16
+						;; bbWeight=1    PerfScore 2.50
+
+; Total bytes of code 35, prolog size 3, PerfScore 15.25, (MethodHash=79ab2c97) for method Silk.NET.Maths.Scalar:Max(long,long):long
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(long,long):long
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00    ] (  4,  3   )    long  ->  [ebp+0x10]  
+;  V01 arg1         [V01    ] (  4,  3   )    long  ->  [ebp+0x08]  
+;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V04 rat0         [V04,T02] (  2,  1.50)     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T03] (  2,  1.50)     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T04] (  2,  1.50)     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T05] (  2,  1.50)     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
+;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
+;  V10 rat6         [V10,T00] (  3,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
+;  V11 rat7         [V11,T01] (  3,  2   )     int  ->  edx         V03.hi(offs=0x04) "field V03.hi (fldOffset=0x4)"
+;
+; Lcl frame size = 0
+
+G_M34166_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M34166_IG02:
+       mov      eax, dword ptr [ebp+08H]
+       cmp      eax, dword ptr [ebp+10H]
+       mov      eax, dword ptr [ebp+0CH]
+       sbb      eax, dword ptr [ebp+14H]
+       jae      SHORT G_M34166_IG04
+						;; bbWeight=1    PerfScore 5.00
+G_M34166_IG03:
+       mov      eax, dword ptr [ebp+08H]
+       mov      edx, dword ptr [ebp+0CH]
+       jmp      SHORT G_M34166_IG05
+						;; bbWeight=0.50 PerfScore 2.00
+G_M34166_IG04:
+       mov      eax, dword ptr [ebp+10H]
+       mov      edx, dword ptr [ebp+14H]
+						;; bbWeight=0.50 PerfScore 1.00
+G_M34166_IG05:
+       pop      ebp
+       ret      16
+						;; bbWeight=1    PerfScore 2.50
+
+; Total bytes of code 35, prolog size 3, PerfScore 15.25, (MethodHash=02627a89) for method Silk.NET.Maths.Scalar:Min(long,long):long
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarUInt64:Negate(long):long
 ; Emitting BLENDED_CODE for generic X86 CPU - Windows
 ; optimized code
@@ -9724,58 +9749,24 @@ G_M21965_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00    ] (  2,  2   )    long  ->  [ebp+0x08]  
-;  V01 rat0         [V01    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V02 rat1         [V02    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V03 rat2         [V03,T00] (  3,  6   )    long  ->  [ebp-0x08]   multireg-ret "ReplaceWithLclVar is creating a new local variable"
+;* V00 arg0         [V00    ] (  0,  0   )    long  ->  zero-ref   
+;* V01 tmp0         [V01    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )    long  ->  zero-ref    ld-addr-op "Inline ldloca(s) first use temp"
+;* V03 rat0         [V03    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
+;* V04 rat1         [V04    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
 ;
-; Lcl frame size = 8
+; Lcl frame size = 0
 
 G_M34306_IG01:
        push     ebp
        mov      ebp, esp
-       sub      esp, 8
-						;; bbWeight=1    PerfScore 1.50
-G_M34306_IG02:
-       push     dword ptr [ebp+0CH]
-       push     dword ptr [ebp+08H]
-       call     Silk.NET.Maths.Scalar:Negate(long):long
-       mov      dword ptr [ebp-08H], eax
-       mov      dword ptr [ebp-04H], edx
-       mov      eax, dword ptr [ebp-08H]
-       mov      edx, dword ptr [ebp-04H]
-						;; bbWeight=1    PerfScore 7.00
-G_M34306_IG03:
-       mov      esp, ebp
-       pop      ebp
-       ret      8
-						;; bbWeight=1    PerfScore 2.75
-
-; Total bytes of code 35, prolog size 6, PerfScore 14.75, (MethodHash=120179fd) for method JITTest.ScalarUInt64:Negate(long):long
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(long):long
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;* V00 arg0         [V00    ] (  0,  0   )    long  ->  zero-ref   
-;* V01 loc0         [V01    ] (  0,  0   )    long  ->  zero-ref    ld-addr-op
-;
-; Lcl frame size = 0
-
-G_M39782_IG01:
-       push     ebp
-       mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
-G_M39782_IG02:
+G_M34306_IG02:
        call     Silk.NET.Maths.Scalar:ThrowInvalidType()
        int3     
 						;; bbWeight=0    PerfScore 0.00
 
-; Total bytes of code 9, prolog size 3, PerfScore 2.15, (MethodHash=f3226499) for method Silk.NET.Maths.Scalar:Negate(long):long
+; Total bytes of code 9, prolog size 3, PerfScore 2.15, (MethodHash=120179fd) for method JITTest.ScalarUInt64:Negate(long):long
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarUInt64:Equal(long,long):bool
@@ -9789,10 +9780,10 @@ G_M39782_IG02:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;  V03 tmp1         [V03,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T01] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T02] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T03] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T04] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
@@ -9853,8 +9844,8 @@ G_M12704_IG02:
 ;
 ;  V00 arg0         [V00    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V01 tmp0         [V01    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V02 rat0         [V02    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V03 rat1         [V03    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V02 rat0         [V02,T00] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V03 rat1         [V03,T01] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
 ;* V04 rat2         [V04    ] (  0,  0   )     int  ->  zero-ref    V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
 ;* V05 rat3         [V05    ] (  0,  0   )     int  ->  zero-ref    V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;
@@ -10516,7 +10507,7 @@ G_M53741_IG03:
 ; Final local variable assignments
 ;
 ;* V00 arg0         [V00    ] (  0,  0   )    long  ->  zero-ref   
-;* V01 tmp0         [V01,T00] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;
 ; Lcl frame size = 0
 
@@ -10718,8 +10709,8 @@ G_M18118_IG03:
 ;  V00 arg0         [V00    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V01 tmp0         [V01    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V02 tmp1         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V03 rat0         [V03    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V04 rat1         [V04    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V03 rat0         [V03,T03] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V04 rat1         [V04,T04] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
 ;* V05 rat2         [V05    ] (  0,  0   )     int  ->  zero-ref    V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
 ;* V06 rat3         [V06    ] (  0,  0   )     int  ->  zero-ref    V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;  V07 rat4         [V07,T01] (  2,  2   )     int  ->  eax         V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
@@ -10770,10 +10761,10 @@ G_M61484_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T02] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T03] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T04] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T05] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
 ;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
 ;  V10 rat6         [V10,T00] (  2,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
@@ -10810,10 +10801,10 @@ G_M14412_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T03] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T04] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T05] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T06] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
 ;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
 ;  V10 rat6         [V10,T01] (  2,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
@@ -10858,10 +10849,10 @@ G_M4587_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T02] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T03] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T04] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T05] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
 ;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
 ;  V10 rat6         [V10,T00] (  2,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
@@ -10898,10 +10889,10 @@ G_M52505_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T03] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T04] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T05] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T06] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
 ;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
 ;  V10 rat6         [V10,T01] (  2,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
@@ -10946,10 +10937,10 @@ G_M41025_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T03] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T04] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T05] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T06] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
 ;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
 ;  V10 rat6         [V10,T01] (  2,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
@@ -10990,89 +10981,50 @@ G_M49182_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00    ] (  2,  2   )    long  ->  [ebp+0x10]  
-;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
-;  V02 rat0         [V02    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V03 rat1         [V03    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V04 rat2         [V04    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V05 rat3         [V05    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
-;  V06 rat4         [V06,T00] (  3,  6   )    long  ->  [ebp-0x08]   multireg-ret "ReplaceWithLclVar is creating a new local variable"
-;
-; Lcl frame size = 8
-
-G_M21159_IG01:
-       push     ebp
-       mov      ebp, esp
-       sub      esp, 8
-						;; bbWeight=1    PerfScore 1.50
-G_M21159_IG02:
-       push     dword ptr [ebp+14H]
-       push     dword ptr [ebp+10H]
-       push     dword ptr [ebp+0CH]
-       push     dword ptr [ebp+08H]
-       call     Silk.NET.Maths.Scalar:Min(long,long):long
-       mov      dword ptr [ebp-08H], eax
-       mov      dword ptr [ebp-04H], edx
-       mov      eax, dword ptr [ebp-08H]
-       mov      edx, dword ptr [ebp-04H]
-						;; bbWeight=1    PerfScore 9.00
-G_M21159_IG03:
-       mov      esp, ebp
-       pop      ebp
-       ret      16
-						;; bbWeight=1    PerfScore 2.75
-
-; Total bytes of code 41, prolog size 6, PerfScore 17.35, (MethodHash=7956ad58) for method JITTest.ScalarInt64:Min(long,long):long
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(long,long):long
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00    ] (  4,  3   )    long  ->  [ebp+0x10]  
 ;  V01 arg1         [V01    ] (  4,  3   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  2,  1.50)     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  2,  1.50)     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  2,  1.50)     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  2,  1.50)     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
-;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
-;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
-;  V10 rat6         [V10,T00] (  3,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
-;  V11 rat7         [V11,T01] (  3,  2   )     int  ->  edx         V03.hi(offs=0x04) "field V03.hi (fldOffset=0x4)"
+;* V04 tmp2         [V04    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V05 rat0         [V05,T02] (  2,  1.50)     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V06 rat1         [V06,T03] (  2,  1.50)     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V07 rat2         [V07,T04] (  2,  1.50)     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V08 rat3         [V08,T05] (  2,  1.50)     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;* V09 rat4         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
+;* V10 rat5         [V10    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
+;* V11 rat6         [V11    ] (  0,  0   )     int  ->  zero-ref    V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
+;* V12 rat7         [V12    ] (  0,  0   )     int  ->  zero-ref    V03.hi(offs=0x04) "field V03.hi (fldOffset=0x4)"
+;  V13 rat8         [V13,T00] (  3,  2   )     int  ->  eax         V04.lo(offs=0x00) "field V04.lo (fldOffset=0x0)"
+;  V14 rat9         [V14,T01] (  3,  2   )     int  ->  edx         V04.hi(offs=0x04) "field V04.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
-G_M34166_IG01:
+G_M21159_IG01:
        push     ebp
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
-G_M34166_IG02:
+G_M21159_IG02:
        mov      eax, dword ptr [ebp+08H]
        cmp      eax, dword ptr [ebp+10H]
        mov      eax, dword ptr [ebp+0CH]
        sbb      eax, dword ptr [ebp+14H]
-       jge      SHORT G_M34166_IG04
+       jge      SHORT G_M21159_IG04
 						;; bbWeight=1    PerfScore 5.00
-G_M34166_IG03:
+G_M21159_IG03:
        mov      eax, dword ptr [ebp+08H]
        mov      edx, dword ptr [ebp+0CH]
-       jmp      SHORT G_M34166_IG05
+       jmp      SHORT G_M21159_IG05
 						;; bbWeight=0.50 PerfScore 2.00
-G_M34166_IG04:
+G_M21159_IG04:
        mov      eax, dword ptr [ebp+10H]
        mov      edx, dword ptr [ebp+14H]
 						;; bbWeight=0.50 PerfScore 1.00
-G_M34166_IG05:
+G_M21159_IG05:
        pop      ebp
        ret      16
 						;; bbWeight=1    PerfScore 2.50
 
-; Total bytes of code 35, prolog size 3, PerfScore 15.25, (MethodHash=02627a89) for method Silk.NET.Maths.Scalar:Min(long,long):long
+; Total bytes of code 35, prolog size 3, PerfScore 15.25, (MethodHash=7956ad58) for method JITTest.ScalarInt64:Min(long,long):long
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarInt64:Max(long,long):long
@@ -11082,89 +11034,50 @@ G_M34166_IG05:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00    ] (  2,  2   )    long  ->  [ebp+0x10]  
-;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
-;  V02 rat0         [V02    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V03 rat1         [V03    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V04 rat2         [V04    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V05 rat3         [V05    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
-;  V06 rat4         [V06,T00] (  3,  6   )    long  ->  [ebp-0x08]   multireg-ret "ReplaceWithLclVar is creating a new local variable"
-;
-; Lcl frame size = 8
-
-G_M33465_IG01:
-       push     ebp
-       mov      ebp, esp
-       sub      esp, 8
-						;; bbWeight=1    PerfScore 1.50
-G_M33465_IG02:
-       push     dword ptr [ebp+14H]
-       push     dword ptr [ebp+10H]
-       push     dword ptr [ebp+0CH]
-       push     dword ptr [ebp+08H]
-       call     Silk.NET.Maths.Scalar:Max(long,long):long
-       mov      dword ptr [ebp-08H], eax
-       mov      dword ptr [ebp-04H], edx
-       mov      eax, dword ptr [ebp-08H]
-       mov      edx, dword ptr [ebp-04H]
-						;; bbWeight=1    PerfScore 9.00
-G_M33465_IG03:
-       mov      esp, ebp
-       pop      ebp
-       ret      16
-						;; bbWeight=1    PerfScore 2.75
-
-; Total bytes of code 41, prolog size 6, PerfScore 17.35, (MethodHash=ae9f7d46) for method JITTest.ScalarInt64:Max(long,long):long
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(long,long):long
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00    ] (  4,  3   )    long  ->  [ebp+0x10]  
 ;  V01 arg1         [V01    ] (  4,  3   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  2,  1.50)     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  2,  1.50)     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  2,  1.50)     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  2,  1.50)     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
-;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
-;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
-;  V10 rat6         [V10,T00] (  3,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
-;  V11 rat7         [V11,T01] (  3,  2   )     int  ->  edx         V03.hi(offs=0x04) "field V03.hi (fldOffset=0x4)"
+;* V04 tmp2         [V04    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V05 rat0         [V05,T02] (  2,  1.50)     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V06 rat1         [V06,T03] (  2,  1.50)     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V07 rat2         [V07,T04] (  2,  1.50)     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V08 rat3         [V08,T05] (  2,  1.50)     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;* V09 rat4         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
+;* V10 rat5         [V10    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
+;* V11 rat6         [V11    ] (  0,  0   )     int  ->  zero-ref    V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
+;* V12 rat7         [V12    ] (  0,  0   )     int  ->  zero-ref    V03.hi(offs=0x04) "field V03.hi (fldOffset=0x4)"
+;  V13 rat8         [V13,T00] (  3,  2   )     int  ->  eax         V04.lo(offs=0x00) "field V04.lo (fldOffset=0x0)"
+;  V14 rat9         [V14,T01] (  3,  2   )     int  ->  edx         V04.hi(offs=0x04) "field V04.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
-G_M54120_IG01:
+G_M33465_IG01:
        push     ebp
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
-G_M54120_IG02:
+G_M33465_IG02:
        mov      eax, dword ptr [ebp+10H]
        cmp      eax, dword ptr [ebp+08H]
        mov      eax, dword ptr [ebp+14H]
        sbb      eax, dword ptr [ebp+0CH]
-       jge      SHORT G_M54120_IG04
+       jge      SHORT G_M33465_IG04
 						;; bbWeight=1    PerfScore 5.00
-G_M54120_IG03:
+G_M33465_IG03:
        mov      eax, dword ptr [ebp+08H]
        mov      edx, dword ptr [ebp+0CH]
-       jmp      SHORT G_M54120_IG05
+       jmp      SHORT G_M33465_IG05
 						;; bbWeight=0.50 PerfScore 2.00
-G_M54120_IG04:
+G_M33465_IG04:
        mov      eax, dword ptr [ebp+10H]
        mov      edx, dword ptr [ebp+14H]
 						;; bbWeight=0.50 PerfScore 1.00
-G_M54120_IG05:
+G_M33465_IG05:
        pop      ebp
        ret      16
 						;; bbWeight=1    PerfScore 2.50
 
-; Total bytes of code 35, prolog size 3, PerfScore 15.25, (MethodHash=79ab2c97) for method Silk.NET.Maths.Scalar:Max(long,long):long
+; Total bytes of code 35, prolog size 3, PerfScore 15.25, (MethodHash=ae9f7d46) for method JITTest.ScalarInt64:Max(long,long):long
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarInt64:Larger(long,long):bool
@@ -11178,10 +11091,10 @@ G_M54120_IG05:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;  V03 tmp1         [V03,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T01] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T02] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T03] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T04] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
@@ -11216,10 +11129,10 @@ G_M30918_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;  V03 tmp1         [V03,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T01] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T02] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T03] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T04] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
@@ -11254,10 +11167,10 @@ G_M41441_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;  V03 tmp1         [V03,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T01] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T02] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T03] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T04] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
@@ -11292,10 +11205,10 @@ G_M7865_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;  V03 tmp1         [V03,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T01] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T02] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T03] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T04] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
@@ -11329,12 +11242,12 @@ G_M43870_IG03:
 ;  V00 arg0         [V00    ] (  2,  2   )    long  ->  [ebp+0x18]  
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x10]  
 ;  V02 arg2         [V02    ] (  2,  2   )    long  ->  [ebp+0x08]  
-;  V03 rat0         [V03    ] (  1,  1   )     int  ->  [ebp+0x18]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V04 rat1         [V04    ] (  1,  1   )     int  ->  [ebp+0x1C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V05 rat2         [V05    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V06 rat3         [V06    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
-;  V07 rat4         [V07    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
-;  V08 rat5         [V08    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
+;  V03 rat0         [V03,T02] (  1,  1   )     int  ->  [ebp+0x18]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V04 rat1         [V04,T03] (  1,  1   )     int  ->  [ebp+0x1C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V05 rat2         [V05,T04] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V06 rat3         [V06,T05] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V07 rat4         [V07,T06] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
+;  V08 rat5         [V08,T07] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
 ;  V09 rat6         [V09,T00] (  3,  6   )    long  ->  [ebp-0x08]   multireg-ret "ReplaceWithLclVar is creating a new local variable"
 ;  V10 rat7         [V10,T01] (  3,  6   )    long  ->  [ebp-0x10]   multireg-ret "ReplaceWithLclVar is creating a new local variable"
 ;
@@ -11374,6 +11287,106 @@ G_M29080_IG03:
 ; Total bytes of code 66, prolog size 6, PerfScore 28.85, (MethodHash=1b498e67) for method JITTest.ScalarInt64:Clamp(long,long,long):long
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(long,long):long
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00    ] (  4,  3   )    long  ->  [ebp+0x10]  
+;  V01 arg1         [V01    ] (  4,  3   )    long  ->  [ebp+0x08]  
+;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V04 rat0         [V04,T02] (  2,  1.50)     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T03] (  2,  1.50)     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T04] (  2,  1.50)     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T05] (  2,  1.50)     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
+;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
+;  V10 rat6         [V10,T00] (  3,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
+;  V11 rat7         [V11,T01] (  3,  2   )     int  ->  edx         V03.hi(offs=0x04) "field V03.hi (fldOffset=0x4)"
+;
+; Lcl frame size = 0
+
+G_M54120_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M54120_IG02:
+       mov      eax, dword ptr [ebp+10H]
+       cmp      eax, dword ptr [ebp+08H]
+       mov      eax, dword ptr [ebp+14H]
+       sbb      eax, dword ptr [ebp+0CH]
+       jge      SHORT G_M54120_IG04
+						;; bbWeight=1    PerfScore 5.00
+G_M54120_IG03:
+       mov      eax, dword ptr [ebp+08H]
+       mov      edx, dword ptr [ebp+0CH]
+       jmp      SHORT G_M54120_IG05
+						;; bbWeight=0.50 PerfScore 2.00
+G_M54120_IG04:
+       mov      eax, dword ptr [ebp+10H]
+       mov      edx, dword ptr [ebp+14H]
+						;; bbWeight=0.50 PerfScore 1.00
+G_M54120_IG05:
+       pop      ebp
+       ret      16
+						;; bbWeight=1    PerfScore 2.50
+
+; Total bytes of code 35, prolog size 3, PerfScore 15.25, (MethodHash=79ab2c97) for method Silk.NET.Maths.Scalar:Max(long,long):long
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(long,long):long
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00    ] (  4,  3   )    long  ->  [ebp+0x10]  
+;  V01 arg1         [V01    ] (  4,  3   )    long  ->  [ebp+0x08]  
+;* V02 tmp0         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V04 rat0         [V04,T02] (  2,  1.50)     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T03] (  2,  1.50)     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T04] (  2,  1.50)     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T05] (  2,  1.50)     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
+;* V09 rat5         [V09    ] (  0,  0   )     int  ->  zero-ref    V02.hi(offs=0x04) "field V02.hi (fldOffset=0x4)"
+;  V10 rat6         [V10,T00] (  3,  2   )     int  ->  eax         V03.lo(offs=0x00) "field V03.lo (fldOffset=0x0)"
+;  V11 rat7         [V11,T01] (  3,  2   )     int  ->  edx         V03.hi(offs=0x04) "field V03.hi (fldOffset=0x4)"
+;
+; Lcl frame size = 0
+
+G_M34166_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M34166_IG02:
+       mov      eax, dword ptr [ebp+08H]
+       cmp      eax, dword ptr [ebp+10H]
+       mov      eax, dword ptr [ebp+0CH]
+       sbb      eax, dword ptr [ebp+14H]
+       jge      SHORT G_M34166_IG04
+						;; bbWeight=1    PerfScore 5.00
+G_M34166_IG03:
+       mov      eax, dword ptr [ebp+08H]
+       mov      edx, dword ptr [ebp+0CH]
+       jmp      SHORT G_M34166_IG05
+						;; bbWeight=0.50 PerfScore 2.00
+G_M34166_IG04:
+       mov      eax, dword ptr [ebp+10H]
+       mov      edx, dword ptr [ebp+14H]
+						;; bbWeight=0.50 PerfScore 1.00
+G_M34166_IG05:
+       pop      ebp
+       ret      16
+						;; bbWeight=1    PerfScore 2.50
+
+; Total bytes of code 35, prolog size 3, PerfScore 15.25, (MethodHash=02627a89) for method Silk.NET.Maths.Scalar:Min(long,long):long
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarInt64:Negate(long):long
 ; Emitting BLENDED_CODE for generic X86 CPU - Windows
 ; optimized code
@@ -11382,66 +11395,31 @@ G_M29080_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00    ] (  2,  2   )    long  ->  [ebp+0x08]  
-;  V01 rat0         [V01    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V02 rat1         [V02    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V03 rat2         [V03,T00] (  3,  6   )    long  ->  [ebp-0x08]   multireg-ret "ReplaceWithLclVar is creating a new local variable"
+;* V01 tmp0         [V01    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V02 rat0         [V02,T02] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V03 rat1         [V03,T03] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V04 rat2         [V04,T00] (  2,  2   )     int  ->  eax         V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V05 rat3         [V05,T01] (  2,  2   )     int  ->  edx         V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;
-; Lcl frame size = 8
+; Lcl frame size = 0
 
 G_M60599_IG01:
        push     ebp
        mov      ebp, esp
-       sub      esp, 8
-						;; bbWeight=1    PerfScore 1.50
-G_M60599_IG02:
-       push     dword ptr [ebp+0CH]
-       push     dword ptr [ebp+08H]
-       call     Silk.NET.Maths.Scalar:Negate(long):long
-       mov      dword ptr [ebp-08H], eax
-       mov      dword ptr [ebp-04H], edx
-       mov      eax, dword ptr [ebp-08H]
-       mov      edx, dword ptr [ebp-04H]
-						;; bbWeight=1    PerfScore 7.00
-G_M60599_IG03:
-       mov      esp, ebp
-       pop      ebp
-       ret      8
-						;; bbWeight=1    PerfScore 2.75
-
-; Total bytes of code 35, prolog size 6, PerfScore 14.75, (MethodHash=3ce51348) for method JITTest.ScalarInt64:Negate(long):long
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(long):long
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00    ] (  2,  2   )    long  ->  [ebp+0x08]  
-;* V01 loc0         [V01    ] (  0,  0   )    long  ->  zero-ref    ld-addr-op
-;  V02 rat0         [V02    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V03 rat1         [V03    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;
-; Lcl frame size = 0
-
-G_M39782_IG01:
-       push     ebp
-       mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
-G_M39782_IG02:
+G_M60599_IG02:
        mov      eax, dword ptr [ebp+08H]
        mov      edx, dword ptr [ebp+0CH]
        neg      eax
        adc      edx, 0
        neg      edx
 						;; bbWeight=1    PerfScore 2.75
-G_M39782_IG03:
+G_M60599_IG03:
        pop      ebp
        ret      8
 						;; bbWeight=1    PerfScore 2.50
 
-; Total bytes of code 20, prolog size 3, PerfScore 8.50, (MethodHash=f3226499) for method Silk.NET.Maths.Scalar:Negate(long):long
+; Total bytes of code 20, prolog size 3, PerfScore 8.50, (MethodHash=3ce51348) for method JITTest.ScalarInt64:Negate(long):long
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarInt64:Equal(long,long):bool
@@ -11455,10 +11433,10 @@ G_M39782_IG03:
 ;  V01 arg1         [V01    ] (  2,  2   )    long  ->  [ebp+0x08]  
 ;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
 ;  V03 tmp1         [V03,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
-;  V06 rat2         [V06    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
-;  V07 rat3         [V07    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T01] (  1,  1   )     int  ->  [ebp+0x10]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T02] (  1,  1   )     int  ->  [ebp+0x14]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V06 rat2         [V06,T03] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
+;  V07 rat3         [V07,T04] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;
 ; Lcl frame size = 0
 
@@ -11521,8 +11499,8 @@ G_M2197_IG02:
 ;* V01 tmp0         [V01    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V02 tmp1         [V02    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
 ;* V03 tmp2         [V03    ] (  0,  0   )    long  ->  zero-ref    "Inlining Arg"
-;  V04 rat0         [V04    ] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
-;  V05 rat1         [V05    ] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
+;  V04 rat0         [V04,T02] (  1,  1   )     int  ->  [ebp+0x08]   do-not-enreg[] V00.lo(offs=0x00) "field V00.lo (fldOffset=0x0)"
+;  V05 rat1         [V05,T03] (  1,  1   )     int  ->  [ebp+0x0C]   do-not-enreg[] V00.hi(offs=0x04) "field V00.hi (fldOffset=0x4)"
 ;* V06 rat2         [V06    ] (  0,  0   )     int  ->  zero-ref    V01.lo(offs=0x00) "field V01.lo (fldOffset=0x0)"
 ;* V07 rat3         [V07    ] (  0,  0   )     int  ->  zero-ref    V01.hi(offs=0x04) "field V01.hi (fldOffset=0x4)"
 ;* V08 rat4         [V08    ] (  0,  0   )     int  ->  zero-ref    V02.lo(offs=0x00) "field V02.lo (fldOffset=0x0)"
@@ -12102,10 +12080,11 @@ G_M49115_IG68:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;  V01 tmp0         [V01,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V04 tmp3         [V04,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x04]
 ;
 ; Lcl frame size = 4
@@ -12149,16 +12128,17 @@ G_M27459_IG03:
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
 ;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;  V02 tmp0         [V02,T02] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V02 tmp0         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;  V05 tmp3         [V05,T07] (  2,  4   )   float  ->  [ebp-0x0C]   "non-inline candidate call"
 ;  V06 tmp4         [V06,T01] (  3,  6   )     ref  ->  edi         class-hnd exact "Single-def Box Helper"
 ;  V07 tmp5         [V07,T00] (  4,  6.50)     ref  ->  edi         "inline UNBOX clone1"
-;  V08 tmp6         [V08,T05] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V09 tmp7         [V09,T06] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V10 tmp8         [V10,T03] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V11 tmp9         [V11,T04] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V08 tmp6         [V08,T05] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V09 tmp7         [V09,T06] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V10 tmp8         [V10,T02] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V11 tmp9         [V11,T03] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T04] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x10]
 ;
 ; Lcl frame size = 8
@@ -12204,7 +12184,7 @@ G_M56341_IG03:
        call     CORINFO_HELP_UNBOX
 						;; bbWeight=0.25 PerfScore 0.38
 G_M56341_IG04:
-       movsx    eax, word  ptr [edi+4]
+       movzx    eax, word  ptr [edi+4]
 						;; bbWeight=1    PerfScore 2.00
 G_M56341_IG05:
        lea      esp, [ebp-08H]
@@ -12225,10 +12205,11 @@ G_M56341_IG05:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;  V01 tmp0         [V01,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V04 tmp3         [V04,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x04]
 ;
 ; Lcl frame size = 4
@@ -12271,10 +12252,11 @@ G_M22342_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;  V01 tmp0         [V01,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V04 tmp3         [V04,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x04]
 ;
 ; Lcl frame size = 4
@@ -12316,8 +12298,10 @@ G_M23790_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;* V00 tmp0         [V00    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
-;  V01 tmp1         [V01,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
+;  V02 tmp2         [V02,T00] (  2,  2   )  ushort  ->  eax         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
+;  V03 tmp3         [V03,T01] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 0
 
@@ -12349,8 +12333,10 @@ RWD00  dd	3F800000h
 ; partially interruptible
 ; Final local variable assignments
 ;
-;* V00 tmp0         [V00    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
-;  V01 tmp1         [V01,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
+;* V01 tmp1         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
+;  V02 tmp2         [V02,T00] (  2,  2   )  ushort  ->  eax         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
+;  V03 tmp3         [V03,T01] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 0
 
@@ -12436,7 +12422,8 @@ G_M63798_IG06:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 tmp0         [V00,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
+;  V01 tmp1         [V01,T00] (  2,  2   )  ushort  ->  eax         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 0
 
@@ -12469,7 +12456,8 @@ RWD08  dq	400921FB54442D18h
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 tmp0         [V00,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
+;  V01 tmp1         [V01,T00] (  2,  2   )  ushort  ->  eax         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 0
 
@@ -12502,7 +12490,8 @@ RWD08  dq	401921FB54442D18h
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 tmp0         [V00,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
+;  V01 tmp1         [V01,T00] (  2,  2   )  ushort  ->  eax         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 0
 
@@ -12535,9 +12524,10 @@ RWD08  dq	3FF921FB54442D18h
 ; partially interruptible
 ; Final local variable assignments
 ;
-;* V00 tmp0         [V00    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V01 tmp1         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "NewObj constructor temp"
-;* V02 tmp2         [V02    ] (  0,  0   )  ushort  ->  zero-ref    V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V02 tmp2         [V02,T00] (  2,  2   )  ushort  ->  eax         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
+;  V03 tmp3         [V03,T01] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 0
 
@@ -12563,9 +12553,10 @@ G_M41528_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;* V00 tmp0         [V00    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V00 tmp0         [V00    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V01 tmp1         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "NewObj constructor temp"
-;* V02 tmp2         [V02    ] (  0,  0   )  ushort  ->  zero-ref    V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V02 tmp2         [V02,T00] (  2,  2   )  ushort  ->  eax         V00._value(offs=0x00) P-INDEP "field V00._value (fldOffset=0x0)"
+;  V03 tmp3         [V03,T01] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 0
 
@@ -12574,7 +12565,7 @@ G_M35184_IG01:
        mov      ebp, esp
 						;; bbWeight=1    PerfScore 1.25
 G_M35184_IG02:
-       mov      eax, -0x400
+       mov      eax, 0xFC00
 						;; bbWeight=1    PerfScore 0.25
 G_M35184_IG03:
        pop      ebp
@@ -12591,9 +12582,11 @@ G_M35184_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T01] (  1,  1   )  double  ->  [ebp+0x08]  
-;* V01 tmp0         [V01    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
-;  V02 tmp1         [V02,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;  V00 arg0         [V00,T02] (  1,  1   )  double  ->  [ebp+0x08]  
+;* V01 tmp0         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
+;  V03 tmp2         [V03,T00] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V04 tmp3         [V04,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;
 ; Lcl frame size = 0
 
@@ -12624,13 +12617,15 @@ G_M25398_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;* V01 tmp0         [V01    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V03 tmp2         [V03,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V03 tmp2         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V04 tmp3         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V05 tmp4         [V05,T03] (  1,  1   )  ushort  ->  [ebp+0x08]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V06 tmp5         [V06,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
-;  V07 tmp6         [V07,T02] (  2,  2   )  ushort  ->  eax         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V05 tmp4         [V05,T04] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V06 tmp5         [V06,T00] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V07 tmp6         [V07,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V08 tmp7         [V08,T02] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V09 tmp8         [V09,T03] (  2,  2   )  ushort  ->  eax         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x04]
 ;
 ; Lcl frame size = 4
@@ -12670,19 +12665,21 @@ G_M39678_IG03:
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
 ;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;* V02 tmp0         [V02    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp0         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V05 tmp3         [V05,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V08 tmp6         [V08,T07] (  2,  4   )   float  ->  [ebp-0x08]   "non-inline candidate call"
-;  V09 tmp7         [V09,T05] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V10 tmp8         [V10,T06] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V11 tmp9         [V11,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T04] (  2,  2   )  ushort  ->  esi         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V08 tmp6         [V08,T08] (  2,  4   )   float  ->  [ebp-0x08]   "non-inline candidate call"
+;  V09 tmp7         [V09,T06] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V10 tmp8         [V10,T07] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V11 tmp9         [V11,T00] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T03] (  2,  2   )  ushort  ->  eax         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T04] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T05] (  2,  2   )  ushort  ->  esi         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x0C]
 ;
 ; Lcl frame size = 8
@@ -12730,19 +12727,21 @@ G_M42172_IG03:
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
 ;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;* V02 tmp0         [V02    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp0         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V05 tmp3         [V05,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V08 tmp6         [V08,T07] (  2,  4   )   float  ->  mm0         "non-inline candidate call"
-;  V09 tmp7         [V09,T05] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V10 tmp8         [V10,T06] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V11 tmp9         [V11,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T04] (  2,  2   )  ushort  ->  esi         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V08 tmp6         [V08,T08] (  2,  4   )   float  ->  mm0         "non-inline candidate call"
+;  V09 tmp7         [V09,T06] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V10 tmp8         [V10,T07] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V11 tmp9         [V11,T00] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T03] (  2,  2   )  ushort  ->  eax         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T04] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T05] (  2,  2   )  ushort  ->  esi         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x08]
 ;
 ; Lcl frame size = 4
@@ -12795,19 +12794,21 @@ G_M18555_IG03:
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
 ;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;* V02 tmp0         [V02    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp0         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V05 tmp3         [V05,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V08 tmp6         [V08,T07] (  2,  4   )   float  ->  [ebp-0x08]   "non-inline candidate call"
-;  V09 tmp7         [V09,T05] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V10 tmp8         [V10,T06] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V11 tmp9         [V11,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T04] (  2,  2   )  ushort  ->  esi         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V08 tmp6         [V08,T08] (  2,  4   )   float  ->  [ebp-0x08]   "non-inline candidate call"
+;  V09 tmp7         [V09,T06] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V10 tmp8         [V10,T07] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V11 tmp9         [V11,T00] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T03] (  2,  2   )  ushort  ->  eax         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T04] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T05] (  2,  2   )  ushort  ->  esi         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x0C]
 ;
 ; Lcl frame size = 8
@@ -12856,19 +12857,21 @@ G_M13193_IG03:
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
 ;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;* V02 tmp0         [V02    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp0         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V05 tmp3         [V05,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V08 tmp6         [V08,T07] (  2,  4   )   float  ->  [ebp-0x08]   "non-inline candidate call"
-;  V09 tmp7         [V09,T05] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V10 tmp8         [V10,T06] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V11 tmp9         [V11,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T04] (  2,  2   )  ushort  ->  esi         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V08 tmp6         [V08,T08] (  2,  4   )   float  ->  [ebp-0x08]   "non-inline candidate call"
+;  V09 tmp7         [V09,T06] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V10 tmp8         [V10,T07] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V11 tmp9         [V11,T00] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T03] (  2,  2   )  ushort  ->  eax         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T04] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T05] (  2,  2   )  ushort  ->  esi         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x0C]
 ;
 ; Lcl frame size = 8
@@ -12916,19 +12919,21 @@ G_M16593_IG03:
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
 ;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;* V02 tmp0         [V02    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp0         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V05 tmp3         [V05,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V08 tmp6         [V08,T07] (  2,  4   )   float  ->  [ebp-0x08]   "non-inline candidate call"
-;  V09 tmp7         [V09,T05] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V10 tmp8         [V10,T06] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V11 tmp9         [V11,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T04] (  2,  2   )  ushort  ->  esi         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V08 tmp6         [V08,T08] (  2,  4   )   float  ->  [ebp-0x08]   "non-inline candidate call"
+;  V09 tmp7         [V09,T06] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V10 tmp8         [V10,T07] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V11 tmp9         [V11,T00] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T03] (  2,  2   )  ushort  ->  eax         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T04] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T05] (  2,  2   )  ushort  ->  esi         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x0C]
 ;
 ; Lcl frame size = 8
@@ -12977,64 +12982,38 @@ G_M26926_IG03:
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
 ;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;  V02 tmp0         [V02,T00] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V03 tmp1         [V03,T01] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;
-; Lcl frame size = 0
-
-G_M33079_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M33079_IG02:
-       mov      eax, dword ptr [ebp+0CH]
-       push     eax
-       mov      eax, dword ptr [ebp+08H]
-       push     eax
-       call     Silk.NET.Maths.Scalar:Min(System.Half,System.Half):System.Half
-						;; bbWeight=1    PerfScore 5.00
-G_M33079_IG03:
-       pop      ebp
-       ret      8
-						;; bbWeight=1    PerfScore 2.50
-
-; Total bytes of code 20, prolog size 3, PerfScore 10.75, (MethodHash=319e7ec8) for method JITTest.ScalarHalf:Min(System.Half,System.Half):System.Half
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(System.Half,System.Half):System.Half
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
-;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;  V02 tmp0         [V02,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V02 tmp0         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V05 tmp3         [V05,T06] (  8,  8   )   float  ->  [ebp-0x08]   "non-inline candidate call"
-;  V06 tmp4         [V06,T08] (  5,  3   )   float  ->  mm0         "Inline return value spill temp"
-;  V07 tmp5         [V07,T07] (  5,  6.50)   float  ->  mm0         "Inlining Arg"
-;  V08 tmp6         [V08,T05] (  2,  0.50)     int  ->  eax         "Inline return value spill temp"
-;* V09 tmp7         [V09    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
-;  V10 tmp8         [V10,T09] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
-;  V11 tmp9         [V11,T03] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T04] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;  V08 tmp6         [V08,T09] (  8,  8   )   float  ->  [ebp-0x08]   "non-inline candidate call"
+;  V09 tmp7         [V09,T11] (  5,  3   )   float  ->  mm0         "Inline return value spill temp"
+;  V10 tmp8         [V10,T10] (  5,  6.50)   float  ->  mm0         "Inlining Arg"
+;  V11 tmp9         [V11,T08] (  2,  0.50)     int  ->  eax         "Inline return value spill temp"
+;* V12 tmp10        [V12    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V13 tmp11        [V13,T12] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
+;  V14 tmp12        [V14,T06] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T07] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T00] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V17 tmp15        [V17,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V18 tmp16        [V18,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V19 tmp17        [V19,T03] (  2,  2   )  ushort  ->  eax         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V20 tmp18        [V20,T04] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V21 tmp19        [V21,T05] (  2,  2   )  ushort  ->  esi         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x0C]
 ;
 ; Lcl frame size = 8
 
-G_M54452_IG01:
+G_M33079_IG01:
        push     ebp
        mov      ebp, esp
        push     esi
        sub      esp, 8
        vzeroupper 
 						;; bbWeight=1    PerfScore 3.50
-G_M54452_IG02:
+G_M33079_IG02:
        movzx    eax, word  ptr [ebp+0CH]
        movzx    esi, word  ptr [ebp+08H]
        push     eax
@@ -13048,47 +13027,47 @@ G_M54452_IG02:
        vmovss   xmm0, dword ptr [ebp-0CH]
        vmovss   xmm1, dword ptr [ebp-08H]
        vucomiss xmm1, xmm0
-       jp       SHORT G_M54452_IG03
-       je       SHORT G_M54452_IG06
+       jp       SHORT G_M33079_IG03
+       je       SHORT G_M33079_IG06
 						;; bbWeight=1    PerfScore 16.50
-G_M54452_IG03:
+G_M33079_IG03:
        vucomiss xmm1, xmm1
-       jp       SHORT G_M54452_IG06
+       jp       SHORT G_M33079_IG06
        vucomiss xmm0, xmm1
-       ja       SHORT G_M54452_IG05
+       ja       SHORT G_M33079_IG05
 						;; bbWeight=0.25 PerfScore 1.00
-G_M54452_IG04:
-       jmp      SHORT G_M54452_IG09
+G_M33079_IG04:
+       jmp      SHORT G_M33079_IG09
 						;; bbWeight=0.50 PerfScore 1.00
-G_M54452_IG05:
+G_M33079_IG05:
        vmovaps  xmm0, xmm1
-       jmp      SHORT G_M54452_IG09
+       jmp      SHORT G_M33079_IG09
 						;; bbWeight=0.50 PerfScore 1.12
-G_M54452_IG06:
+G_M33079_IG06:
        vmovaps  xmm2, xmm1
        vmovd    eax, xmm2
        test     eax, eax
-       jl       SHORT G_M54452_IG08
+       jl       SHORT G_M33079_IG08
 						;; bbWeight=0.25 PerfScore 0.62
-G_M54452_IG07:
-       jmp      SHORT G_M54452_IG09
+G_M33079_IG07:
+       jmp      SHORT G_M33079_IG09
 						;; bbWeight=0.50 PerfScore 1.00
-G_M54452_IG08:
+G_M33079_IG08:
        vmovaps  xmm0, xmm1
 						;; bbWeight=0.50 PerfScore 0.12
-G_M54452_IG09:
+G_M33079_IG09:
        sub      esp, 4
        vmovss   dword ptr [esp], xmm0
        call     System.Half:op_Explicit(float):System.Half
 						;; bbWeight=1    PerfScore 1.75
-G_M54452_IG10:
+G_M33079_IG10:
        lea      esp, [ebp-04H]
        pop      esi
        pop      ebp
        ret      8
 						;; bbWeight=1    PerfScore 3.50
 
-; Total bytes of code 123, prolog size 10, PerfScore 43.63, (MethodHash=80ea2b4b) for method Silk.NET.Maths.Scalar:Min(System.Half,System.Half):System.Half
+; Total bytes of code 123, prolog size 10, PerfScore 43.63, (MethodHash=319e7ec8) for method JITTest.ScalarHalf:Min(System.Half,System.Half):System.Half
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarHalf:Max(System.Half,System.Half):System.Half
@@ -13100,28 +13079,329 @@ G_M54452_IG10:
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
 ;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;  V02 tmp0         [V02,T00] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V03 tmp1         [V03,T01] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;* V02 tmp0         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V05 tmp3         [V05    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;  V08 tmp6         [V08,T09] (  8,  8.50)   float  ->  [ebp-0x08]   "non-inline candidate call"
+;  V09 tmp7         [V09,T11] (  6,  3.50)   float  ->  mm0         "Inline return value spill temp"
+;  V10 tmp8         [V10,T10] (  6,  7   )   float  ->  mm0         "Inlining Arg"
+;  V11 tmp9         [V11,T08] (  2,  0.50)     int  ->  eax         "Inline return value spill temp"
+;* V12 tmp10        [V12    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V13 tmp11        [V13,T12] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
+;  V14 tmp12        [V14,T06] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T07] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T00] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V17 tmp15        [V17,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V18 tmp16        [V18,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V19 tmp17        [V19,T03] (  2,  2   )  ushort  ->  eax         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V20 tmp18        [V20,T04] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V21 tmp19        [V21,T05] (  2,  2   )  ushort  ->  esi         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  TEMP_01                                   float  ->  [ebp-0x0C]
 ;
-; Lcl frame size = 0
+; Lcl frame size = 8
 
 G_M59113_IG01:
        push     ebp
        mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
+       push     esi
+       sub      esp, 8
+       vzeroupper 
+						;; bbWeight=1    PerfScore 3.50
 G_M59113_IG02:
-       mov      eax, dword ptr [ebp+0CH]
+       movzx    eax, word  ptr [ebp+0CH]
+       movzx    esi, word  ptr [ebp+08H]
        push     eax
-       mov      eax, dword ptr [ebp+08H]
-       push     eax
-       call     Silk.NET.Maths.Scalar:Max(System.Half,System.Half):System.Half
-						;; bbWeight=1    PerfScore 5.00
+       call     System.Half:op_Explicit(System.Half):float
+       fstp     dword ptr [ebp-0CH]
+       vmovss   xmm0, dword ptr [ebp-0CH]
+       vmovss   dword ptr [ebp-08H], xmm0
+       push     esi
+       call     System.Half:op_Explicit(System.Half):float
+       fstp     dword ptr [ebp-0CH]
+       vmovss   xmm0, dword ptr [ebp-0CH]
+       vmovss   xmm1, dword ptr [ebp-08H]
+       vucomiss xmm1, xmm0
+       jp       SHORT G_M59113_IG03
+       je       SHORT G_M59113_IG07
+						;; bbWeight=1    PerfScore 16.50
 G_M59113_IG03:
+       vucomiss xmm1, xmm1
+       jp       SHORT G_M59113_IG06
+       vucomiss xmm1, xmm0
+       ja       SHORT G_M59113_IG05
+						;; bbWeight=0.25 PerfScore 1.00
+G_M59113_IG04:
+       jmp      SHORT G_M59113_IG10
+						;; bbWeight=0.50 PerfScore 1.00
+G_M59113_IG05:
+       vmovaps  xmm0, xmm1
+       jmp      SHORT G_M59113_IG10
+						;; bbWeight=0.50 PerfScore 1.12
+G_M59113_IG06:
+       vmovaps  xmm0, xmm1
+       jmp      SHORT G_M59113_IG10
+						;; bbWeight=0.50 PerfScore 1.12
+G_M59113_IG07:
+       vmovaps  xmm2, xmm0
+       vmovd    eax, xmm2
+       test     eax, eax
+       jl       SHORT G_M59113_IG09
+						;; bbWeight=0.25 PerfScore 0.62
+G_M59113_IG08:
+       jmp      SHORT G_M59113_IG10
+						;; bbWeight=0.50 PerfScore 1.00
+G_M59113_IG09:
+       vmovaps  xmm0, xmm1
+						;; bbWeight=0.50 PerfScore 0.12
+G_M59113_IG10:
+       sub      esp, 4
+       vmovss   dword ptr [esp], xmm0
+       call     System.Half:op_Explicit(float):System.Half
+						;; bbWeight=1    PerfScore 1.75
+G_M59113_IG11:
+       lea      esp, [ebp-04H]
+       pop      esi
+       pop      ebp
+       ret      8
+						;; bbWeight=1    PerfScore 3.50
+
+; Total bytes of code 129, prolog size 10, PerfScore 45.45, (MethodHash=3fd21916) for method JITTest.ScalarHalf:Max(System.Half,System.Half):System.Half
+; ============================================================
+
+; Assembly listing for method JITTest.ScalarHalf:Larger(System.Half,System.Half):bool
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
+;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
+;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;  V05 tmp3         [V05,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V08 tmp6         [V08    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V09 tmp7         [V09    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;  V10 tmp8         [V10,T07] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V11 tmp9         [V11,T08] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T02] (  2,  2   )  ushort  ->  edx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T04] (  2,  2   )  ushort  ->  edx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T05] (  2,  2   )  ushort  ->  edx         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
+;  V17 tmp15        [V17,T06] (  2,  2   )  ushort  ->  eax         V09._value(offs=0x00) P-INDEP "field V09._value (fldOffset=0x0)"
+;
+; Lcl frame size = 0
+
+G_M61364_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M61364_IG02:
+       movzx    eax, word  ptr [ebp+0CH]
+       movzx    edx, word  ptr [ebp+08H]
+       push     edx
+       push     eax
+       call     System.Half:op_LessThan(System.Half,System.Half):bool
+       movzx    eax, al
+						;; bbWeight=1    PerfScore 5.25
+G_M61364_IG03:
        pop      ebp
        ret      8
 						;; bbWeight=1    PerfScore 2.50
 
-; Total bytes of code 20, prolog size 3, PerfScore 10.75, (MethodHash=3fd21916) for method JITTest.ScalarHalf:Max(System.Half,System.Half):System.Half
+; Total bytes of code 25, prolog size 3, PerfScore 11.50, (MethodHash=945b104b) for method JITTest.ScalarHalf:Larger(System.Half,System.Half):bool
+; ============================================================
+
+; Assembly listing for method JITTest.ScalarHalf:Smaller(System.Half,System.Half):bool
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
+;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
+;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;  V05 tmp3         [V05,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;  V08 tmp6         [V08,T05] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V09 tmp7         [V09,T06] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V10 tmp8         [V10,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V11 tmp9         [V11,T02] (  2,  2   )  ushort  ->  edx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T04] (  2,  2   )  ushort  ->  edx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;
+; Lcl frame size = 0
+
+G_M14547_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M14547_IG02:
+       movzx    eax, word  ptr [ebp+0CH]
+       movzx    edx, word  ptr [ebp+08H]
+       push     eax
+       push     edx
+       call     System.Half:op_LessThan(System.Half,System.Half):bool
+       movzx    eax, al
+						;; bbWeight=1    PerfScore 5.25
+G_M14547_IG03:
+       pop      ebp
+       ret      8
+						;; bbWeight=1    PerfScore 2.50
+
+; Total bytes of code 25, prolog size 3, PerfScore 11.50, (MethodHash=d1b3c72c) for method JITTest.ScalarHalf:Smaller(System.Half,System.Half):bool
+; ============================================================
+
+; Assembly listing for method JITTest.ScalarHalf:LargerEquals(System.Half,System.Half):bool
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
+;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
+;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;  V05 tmp3         [V05,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V08 tmp6         [V08    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V09 tmp7         [V09    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;  V10 tmp8         [V10,T07] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V11 tmp9         [V11,T08] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T02] (  2,  2   )  ushort  ->  edx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T04] (  2,  2   )  ushort  ->  edx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;  V16 tmp14        [V16,T05] (  2,  2   )  ushort  ->  edx         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
+;  V17 tmp15        [V17,T06] (  2,  2   )  ushort  ->  eax         V09._value(offs=0x00) P-INDEP "field V09._value (fldOffset=0x0)"
+;
+; Lcl frame size = 0
+
+G_M39755_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M39755_IG02:
+       movzx    eax, word  ptr [ebp+0CH]
+       movzx    edx, word  ptr [ebp+08H]
+       push     edx
+       push     eax
+       call     System.Half:op_LessThanOrEqual(System.Half,System.Half):bool
+       movzx    eax, al
+						;; bbWeight=1    PerfScore 5.25
+G_M39755_IG03:
+       pop      ebp
+       ret      8
+						;; bbWeight=1    PerfScore 2.50
+
+; Total bytes of code 25, prolog size 3, PerfScore 11.50, (MethodHash=cff164b4) for method JITTest.ScalarHalf:LargerEquals(System.Half,System.Half):bool
+; ============================================================
+
+; Assembly listing for method JITTest.ScalarHalf:SmallerEquals(System.Half,System.Half):bool
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
+;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
+;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;  V05 tmp3         [V05,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;  V08 tmp6         [V08,T05] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V09 tmp7         [V09,T06] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V10 tmp8         [V10,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V11 tmp9         [V11,T02] (  2,  2   )  ushort  ->  edx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T04] (  2,  2   )  ushort  ->  edx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
+;
+; Lcl frame size = 0
+
+G_M748_IG01:
+       push     ebp
+       mov      ebp, esp
+						;; bbWeight=1    PerfScore 1.25
+G_M748_IG02:
+       movzx    eax, word  ptr [ebp+0CH]
+       movzx    edx, word  ptr [ebp+08H]
+       push     eax
+       push     edx
+       call     System.Half:op_LessThanOrEqual(System.Half,System.Half):bool
+       movzx    eax, al
+						;; bbWeight=1    PerfScore 5.25
+G_M748_IG03:
+       pop      ebp
+       ret      8
+						;; bbWeight=1    PerfScore 2.50
+
+; Total bytes of code 25, prolog size 3, PerfScore 11.50, (MethodHash=c272fd13) for method JITTest.ScalarHalf:SmallerEquals(System.Half,System.Half):bool
+; ============================================================
+
+; Assembly listing for method JITTest.ScalarHalf:Clamp(System.Half,System.Half,System.Half):System.Half
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x10]  
+;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
+;  V02 arg2         [V02    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
+;* V03 tmp0         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V04 tmp1         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V05 tmp2         [V05    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;* V06 tmp3         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "struct address for call/obj"
+;  V07 tmp4         [V07,T04] (  1,  1   )  ushort  ->  [ebp+0x10]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V08 tmp5         [V08,T05] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V09 tmp6         [V09,T06] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V02._value(offs=0x00) P-DEP "field V02._value (fldOffset=0x0)"
+;  V10 tmp7         [V10,T00] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V11 tmp8         [V11,T01] (  2,  2   )  ushort  ->  edx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V12 tmp9         [V12,T02] (  2,  2   )  ushort  ->  esi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
+;  V13 tmp10        [V13,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;
+; Lcl frame size = 0
+
+G_M2250_IG01:
+       push     ebp
+       mov      ebp, esp
+       push     esi
+						;; bbWeight=1    PerfScore 2.25
+G_M2250_IG02:
+       movzx    eax, word  ptr [ebp+10H]
+       movzx    edx, word  ptr [ebp+0CH]
+       movzx    esi, word  ptr [ebp+08H]
+       push     eax
+       push     edx
+       call     Silk.NET.Maths.Scalar:Max(System.Half,System.Half):System.Half
+       push     eax
+       push     esi
+       call     Silk.NET.Maths.Scalar:Min(System.Half,System.Half):System.Half
+						;; bbWeight=1    PerfScore 9.00
+G_M2250_IG03:
+       pop      esi
+       pop      ebp
+       ret      12
+						;; bbWeight=1    PerfScore 3.00
+
+; Total bytes of code 35, prolog size 4, PerfScore 17.75, (MethodHash=a1d5f735) for method JITTest.ScalarHalf:Clamp(System.Half,System.Half,System.Half):System.Half
 ; ============================================================
 
 ; Assembly listing for method Silk.NET.Maths.Scalar:Max(System.Half,System.Half):System.Half
@@ -13133,7 +13413,7 @@ G_M59113_IG03:
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
 ;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;  V02 tmp0         [V02,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V02 tmp0         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;  V05 tmp3         [V05,T06] (  8,  8.50)   float  ->  [ebp-0x08]   "non-inline candidate call"
@@ -13142,10 +13422,11 @@ G_M59113_IG03:
 ;  V08 tmp6         [V08,T05] (  2,  0.50)     int  ->  eax         "Inline return value spill temp"
 ;* V09 tmp7         [V09    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
 ;  V10 tmp8         [V10,T09] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
-;  V11 tmp9         [V11,T03] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T04] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V11 tmp9         [V11,T03] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T04] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T00] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x0C]
 ;
 ; Lcl frame size = 8
@@ -13218,7 +13499,7 @@ G_M21738_IG11:
 ; Total bytes of code 129, prolog size 10, PerfScore 45.45, (MethodHash=36e9ab15) for method Silk.NET.Maths.Scalar:Max(System.Half,System.Half):System.Half
 ; ============================================================
 
-; Assembly listing for method JITTest.ScalarHalf:Larger(System.Half,System.Half):bool
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(System.Half,System.Half):System.Half
 ; Emitting BLENDED_CODE for generic X86 CPU - Windows
 ; optimized code
 ; ebp based frame
@@ -13227,232 +13508,86 @@ G_M21738_IG11:
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
 ;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
+;* V02 tmp0         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V05 tmp3         [V05,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;* V08 tmp6         [V08    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;* V09 tmp7         [V09    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V10 tmp8         [V10,T07] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V11 tmp9         [V11,T08] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T02] (  2,  2   )  ushort  ->  edx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
-;  V15 tmp13        [V15,T04] (  2,  2   )  ushort  ->  edx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
-;  V16 tmp14        [V16,T05] (  2,  2   )  ushort  ->  edx         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
-;  V17 tmp15        [V17,T06] (  2,  2   )  ushort  ->  eax         V09._value(offs=0x00) P-INDEP "field V09._value (fldOffset=0x0)"
+;  V05 tmp3         [V05,T06] (  8,  8   )   float  ->  [ebp-0x08]   "non-inline candidate call"
+;  V06 tmp4         [V06,T08] (  5,  3   )   float  ->  mm0         "Inline return value spill temp"
+;  V07 tmp5         [V07,T07] (  5,  6.50)   float  ->  mm0         "Inlining Arg"
+;  V08 tmp6         [V08,T05] (  2,  0.50)     int  ->  eax         "Inline return value spill temp"
+;* V09 tmp7         [V09    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V10 tmp8         [V10,T09] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
+;  V11 tmp9         [V11,T03] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T04] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T00] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V14 tmp12        [V14,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V15 tmp13        [V15,T02] (  2,  2   )  ushort  ->  esi         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  TEMP_01                                   float  ->  [ebp-0x0C]
 ;
-; Lcl frame size = 0
+; Lcl frame size = 8
 
-G_M61364_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M61364_IG02:
-       movzx    eax, word  ptr [ebp+0CH]
-       movzx    edx, word  ptr [ebp+08H]
-       push     edx
-       push     eax
-       call     System.Half:op_LessThan(System.Half,System.Half):bool
-       movzx    eax, al
-						;; bbWeight=1    PerfScore 5.25
-G_M61364_IG03:
-       pop      ebp
-       ret      8
-						;; bbWeight=1    PerfScore 2.50
-
-; Total bytes of code 25, prolog size 3, PerfScore 11.50, (MethodHash=945b104b) for method JITTest.ScalarHalf:Larger(System.Half,System.Half):bool
-; ============================================================
-
-; Assembly listing for method JITTest.ScalarHalf:Smaller(System.Half,System.Half):bool
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
-;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
-;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V05 tmp3         [V05,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V08 tmp6         [V08,T05] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V09 tmp7         [V09,T06] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V10 tmp8         [V10,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V11 tmp9         [V11,T02] (  2,  2   )  ushort  ->  edx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T04] (  2,  2   )  ushort  ->  edx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
-;
-; Lcl frame size = 0
-
-G_M14547_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M14547_IG02:
-       movzx    eax, word  ptr [ebp+0CH]
-       movzx    edx, word  ptr [ebp+08H]
-       push     eax
-       push     edx
-       call     System.Half:op_LessThan(System.Half,System.Half):bool
-       movzx    eax, al
-						;; bbWeight=1    PerfScore 5.25
-G_M14547_IG03:
-       pop      ebp
-       ret      8
-						;; bbWeight=1    PerfScore 2.50
-
-; Total bytes of code 25, prolog size 3, PerfScore 11.50, (MethodHash=d1b3c72c) for method JITTest.ScalarHalf:Smaller(System.Half,System.Half):bool
-; ============================================================
-
-; Assembly listing for method JITTest.ScalarHalf:LargerEquals(System.Half,System.Half):bool
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
-;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
-;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V05 tmp3         [V05,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;* V08 tmp6         [V08    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;* V09 tmp7         [V09    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V10 tmp8         [V10,T07] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V11 tmp9         [V11,T08] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T02] (  2,  2   )  ushort  ->  edx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
-;  V15 tmp13        [V15,T04] (  2,  2   )  ushort  ->  edx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
-;  V16 tmp14        [V16,T05] (  2,  2   )  ushort  ->  edx         V08._value(offs=0x00) P-INDEP "field V08._value (fldOffset=0x0)"
-;  V17 tmp15        [V17,T06] (  2,  2   )  ushort  ->  eax         V09._value(offs=0x00) P-INDEP "field V09._value (fldOffset=0x0)"
-;
-; Lcl frame size = 0
-
-G_M39755_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M39755_IG02:
-       movzx    eax, word  ptr [ebp+0CH]
-       movzx    edx, word  ptr [ebp+08H]
-       push     edx
-       push     eax
-       call     System.Half:op_LessThanOrEqual(System.Half,System.Half):bool
-       movzx    eax, al
-						;; bbWeight=1    PerfScore 5.25
-G_M39755_IG03:
-       pop      ebp
-       ret      8
-						;; bbWeight=1    PerfScore 2.50
-
-; Total bytes of code 25, prolog size 3, PerfScore 11.50, (MethodHash=cff164b4) for method JITTest.ScalarHalf:LargerEquals(System.Half,System.Half):bool
-; ============================================================
-
-; Assembly listing for method JITTest.ScalarHalf:SmallerEquals(System.Half,System.Half):bool
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
-;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;* V02 tmp0         [V02    ] (  0,  0   )    bool  ->  zero-ref    "Inline return value spill temp"
-;* V03 tmp1         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;* V04 tmp2         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V05 tmp3         [V05,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
-;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V08 tmp6         [V08,T05] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V09 tmp7         [V09,T06] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V10 tmp8         [V10,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V11 tmp9         [V11,T02] (  2,  2   )  ushort  ->  edx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T04] (  2,  2   )  ushort  ->  edx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
-;
-; Lcl frame size = 0
-
-G_M748_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M748_IG02:
-       movzx    eax, word  ptr [ebp+0CH]
-       movzx    edx, word  ptr [ebp+08H]
-       push     eax
-       push     edx
-       call     System.Half:op_LessThanOrEqual(System.Half,System.Half):bool
-       movzx    eax, al
-						;; bbWeight=1    PerfScore 5.25
-G_M748_IG03:
-       pop      ebp
-       ret      8
-						;; bbWeight=1    PerfScore 2.50
-
-; Total bytes of code 25, prolog size 3, PerfScore 11.50, (MethodHash=c272fd13) for method JITTest.ScalarHalf:SmallerEquals(System.Half,System.Half):bool
-; ============================================================
-
-; Assembly listing for method JITTest.ScalarHalf:Clamp(System.Half,System.Half,System.Half):System.Half
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x10]  
-;  V01 arg1         [V01    ] (  1,  1   )  struct ( 4) [ebp+0x0C]  
-;  V02 arg2         [V02    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;* V03 tmp0         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;* V04 tmp1         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;* V05 tmp2         [V05    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V06 tmp3         [V06    ] (  2,  4   )  struct ( 4) [ebp-0x08]   do-not-enreg[SF] "struct address for call/obj"
-;  V07 tmp4         [V07,T03] (  1,  1   )  ushort  ->  [ebp+0x10]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V08 tmp5         [V08,T04] (  1,  1   )  ushort  ->  [ebp+0x0C]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V09 tmp6         [V09,T05] (  1,  1   )  ushort  ->  [ebp+0x08]   V02._value(offs=0x00) P-DEP "field V02._value (fldOffset=0x0)"
-;  V10 tmp7         [V10,T00] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V11 tmp8         [V11,T01] (  2,  2   )  ushort  ->  edx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V12 tmp9         [V12,T02] (  2,  2   )  ushort  ->  esi         V05._value(offs=0x00) P-INDEP "field V05._value (fldOffset=0x0)"
-;  V13 tmp10        [V13    ] (  2,  4   )  ushort  ->  [ebp-0x08]   do-not-enreg[] V06._value(offs=0x00) P-DEP "field V06._value (fldOffset=0x0)"
-;
-; Lcl frame size = 4
-
-G_M2250_IG01:
+G_M54452_IG01:
        push     ebp
        mov      ebp, esp
        push     esi
-       push     eax
-						;; bbWeight=1    PerfScore 3.25
-G_M2250_IG02:
-       movzx    eax, word  ptr [ebp+10H]
-       movzx    edx, word  ptr [ebp+0CH]
+       sub      esp, 8
+       vzeroupper 
+						;; bbWeight=1    PerfScore 3.50
+G_M54452_IG02:
+       movzx    eax, word  ptr [ebp+0CH]
        movzx    esi, word  ptr [ebp+08H]
        push     eax
-       push     edx
-       call     Silk.NET.Maths.Scalar:Max(System.Half,System.Half):System.Half
-       mov      word  ptr [ebp-08H], ax
-       mov      eax, dword ptr [ebp-08H]
-       push     eax
+       call     System.Half:op_Explicit(System.Half):float
+       fstp     dword ptr [ebp-0CH]
+       vmovss   xmm0, dword ptr [ebp-0CH]
+       vmovss   dword ptr [ebp-08H], xmm0
        push     esi
-       call     Silk.NET.Maths.Scalar:Min(System.Half,System.Half):System.Half
-						;; bbWeight=1    PerfScore 11.00
-G_M2250_IG03:
-       pop      ecx
+       call     System.Half:op_Explicit(System.Half):float
+       fstp     dword ptr [ebp-0CH]
+       vmovss   xmm0, dword ptr [ebp-0CH]
+       vmovss   xmm1, dword ptr [ebp-08H]
+       vucomiss xmm1, xmm0
+       jp       SHORT G_M54452_IG03
+       je       SHORT G_M54452_IG06
+						;; bbWeight=1    PerfScore 16.50
+G_M54452_IG03:
+       vucomiss xmm1, xmm1
+       jp       SHORT G_M54452_IG06
+       vucomiss xmm0, xmm1
+       ja       SHORT G_M54452_IG05
+						;; bbWeight=0.25 PerfScore 1.00
+G_M54452_IG04:
+       jmp      SHORT G_M54452_IG09
+						;; bbWeight=0.50 PerfScore 1.00
+G_M54452_IG05:
+       vmovaps  xmm0, xmm1
+       jmp      SHORT G_M54452_IG09
+						;; bbWeight=0.50 PerfScore 1.12
+G_M54452_IG06:
+       vmovaps  xmm2, xmm1
+       vmovd    eax, xmm2
+       test     eax, eax
+       jl       SHORT G_M54452_IG08
+						;; bbWeight=0.25 PerfScore 0.62
+G_M54452_IG07:
+       jmp      SHORT G_M54452_IG09
+						;; bbWeight=0.50 PerfScore 1.00
+G_M54452_IG08:
+       vmovaps  xmm0, xmm1
+						;; bbWeight=0.50 PerfScore 0.12
+G_M54452_IG09:
+       sub      esp, 4
+       vmovss   dword ptr [esp], xmm0
+       call     System.Half:op_Explicit(float):System.Half
+						;; bbWeight=1    PerfScore 1.75
+G_M54452_IG10:
+       lea      esp, [ebp-04H]
        pop      esi
        pop      ebp
-       ret      12
+       ret      8
 						;; bbWeight=1    PerfScore 3.50
 
-; Total bytes of code 44, prolog size 5, PerfScore 22.15, (MethodHash=a1d5f735) for method JITTest.ScalarHalf:Clamp(System.Half,System.Half,System.Half):System.Half
+; Total bytes of code 123, prolog size 10, PerfScore 43.63, (MethodHash=80ea2b4b) for method Silk.NET.Maths.Scalar:Min(System.Half,System.Half):System.Half
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarHalf:Negate(System.Half):System.Half
@@ -13463,50 +13598,23 @@ G_M2250_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;  V01 tmp0         [V01,T00] (  1,  1   )  ushort  ->  [ebp+0x08]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;
-; Lcl frame size = 0
-
-G_M28005_IG01:
-       push     ebp
-       mov      ebp, esp
-						;; bbWeight=1    PerfScore 1.25
-G_M28005_IG02:
-       mov      eax, dword ptr [ebp+08H]
-       push     eax
-       call     Silk.NET.Maths.Scalar:Negate(System.Half):System.Half
-						;; bbWeight=1    PerfScore 3.00
-G_M28005_IG03:
-       pop      ebp
-       ret      4
-						;; bbWeight=1    PerfScore 2.50
-
-; Total bytes of code 16, prolog size 3, PerfScore 8.35, (MethodHash=ccc8929a) for method JITTest.ScalarHalf:Negate(System.Half):System.Half
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(System.Half):System.Half
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;* V01 loc0         [V01    ] (  0,  0   )  struct ( 4) zero-ref    ld-addr-op
-;  V02 tmp0         [V02,T00] (  1,  1   )  ushort  ->  [ebp+0x08]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;* V03 tmp1         [V03    ] (  0,  0   )  ushort  ->  zero-ref    V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;* V01 tmp0         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
+;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
+;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x04]
 ;
 ; Lcl frame size = 4
 
-G_M11590_IG01:
+G_M28005_IG01:
        push     ebp
        mov      ebp, esp
        push     eax
        vzeroupper 
 						;; bbWeight=1    PerfScore 3.25
-G_M11590_IG02:
-       mov      eax, dword ptr [ebp+08H]
+G_M28005_IG02:
+       movzx    eax, word  ptr [ebp+08H]
        push     eax
        call     System.Half:op_Explicit(System.Half):float
        fstp     dword ptr [ebp-04H]
@@ -13517,7 +13625,7 @@ G_M11590_IG02:
        vmovss   dword ptr [esp], xmm0
        call     System.Half:op_Explicit(float):System.Half
 						;; bbWeight=1    PerfScore 9.58
-G_M11590_IG03:
+G_M28005_IG03:
        mov      esp, ebp
        pop      ebp
        ret      4
@@ -13525,7 +13633,7 @@ G_M11590_IG03:
 RWD00  dd	80000000h
 
 
-; Total bytes of code 55, prolog size 7, PerfScore 21.48, (MethodHash=8889d2b9) for method Silk.NET.Maths.Scalar:Negate(System.Half):System.Half
+; Total bytes of code 56, prolog size 7, PerfScore 21.58, (MethodHash=ccc8929a) for method JITTest.ScalarHalf:Negate(System.Half):System.Half
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarHalf:Equal(System.Half,System.Half):bool
@@ -13543,40 +13651,33 @@ RWD00  dd	80000000h
 ;  V05 tmp3         [V05,T00] (  2,  2   )    bool  ->  eax         "Inline return value spill temp"
 ;* V06 tmp4         [V06    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
 ;* V07 tmp5         [V07    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V08 tmp6         [V08    ] (  2,  4   )  struct ( 4) [ebp-0x04]   do-not-enreg[XS] addr-exposed ld-addr-op "Inlining Arg"
-;* V09 tmp7         [V09    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V10 tmp8         [V10,T06] (  1,  1   )  ushort  ->  [ebp+0x0C]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V11 tmp9         [V11,T07] (  1,  1   )  ushort  ->  [ebp+0x08]   V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
-;  V12 tmp10        [V12,T01] (  2,  2   )  ushort  ->  ecx         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
-;  V13 tmp11        [V13,T02] (  2,  2   )  ushort  ->  eax         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
-;  V14 tmp12        [V14,T03] (  2,  2   )  ushort  ->  ecx         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
-;  V15 tmp13        [V15,T04] (  2,  2   )  ushort  ->  eax         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
-;  V16 tmp14        [V16    ] (  2,  3   )  ushort  ->  [ebp-0x04]   do-not-enreg[X] addr-exposed V08._value(offs=0x00) P-DEP "field V08._value (fldOffset=0x0)"
-;  V17 tmp15        [V17,T05] (  2,  2   )  ushort  ->  eax         V09._value(offs=0x00) P-INDEP "field V09._value (fldOffset=0x0)"
+;  V08 tmp6         [V08,T05] (  1,  1   )  ushort  ->  [ebp+0x0C]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V09 tmp7         [V09,T06] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V01._value(offs=0x00) P-DEP "field V01._value (fldOffset=0x0)"
+;  V10 tmp8         [V10,T01] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V11 tmp9         [V11,T02] (  2,  2   )  ushort  ->  edx         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V12 tmp10        [V12,T03] (  2,  2   )  ushort  ->  eax         V06._value(offs=0x00) P-INDEP "field V06._value (fldOffset=0x0)"
+;  V13 tmp11        [V13,T04] (  2,  2   )  ushort  ->  edx         V07._value(offs=0x00) P-INDEP "field V07._value (fldOffset=0x0)"
 ;
-; Lcl frame size = 4
+; Lcl frame size = 0
 
 G_M21591_IG01:
        push     ebp
        mov      ebp, esp
-       push     eax
-						;; bbWeight=1    PerfScore 2.25
+						;; bbWeight=1    PerfScore 1.25
 G_M21591_IG02:
-       movzx    ecx, word  ptr [ebp+0CH]
-       movzx    eax, word  ptr [ebp+08H]
-       mov      word  ptr [ebp-04H], cx
+       movzx    eax, word  ptr [ebp+0CH]
+       movzx    edx, word  ptr [ebp+08H]
        push     eax
-       lea      ecx, bword ptr [ebp-04H]
-       call     System.Half:Equals(System.Half):bool:this
+       push     edx
+       call     System.Half:op_Equality(System.Half,System.Half):bool
        movzx    eax, al
-						;; bbWeight=1    PerfScore 5.75
+						;; bbWeight=1    PerfScore 5.25
 G_M21591_IG03:
-       mov      esp, ebp
        pop      ebp
        ret      8
-						;; bbWeight=1    PerfScore 2.75
+						;; bbWeight=1    PerfScore 2.50
 
-; Total bytes of code 34, prolog size 4, PerfScore 14.15, (MethodHash=5104aba8) for method JITTest.ScalarHalf:Equal(System.Half,System.Half):bool
+; Total bytes of code 25, prolog size 3, PerfScore 11.50, (MethodHash=5104aba8) for method JITTest.ScalarHalf:Equal(System.Half,System.Half):bool
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarHalf:Acos(System.Half):System.Half
@@ -13587,10 +13688,11 @@ G_M21591_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;  V01 tmp0         [V01,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V04 tmp3         [V04,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x04]
 ;
 ; Lcl frame size = 4
@@ -13633,14 +13735,16 @@ G_M27079_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;* V01 tmp0         [V01    ] (  0,  0   )   short  ->  zero-ref    "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V03 tmp2         [V03,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V03 tmp2         [V03    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V04 tmp3         [V04    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V05 tmp4         [V05,T04] (  2,  4   )   float  ->  mm0         "Inlining Arg"
-;  V06 tmp5         [V06,T03] (  1,  1   )  ushort  ->  [ebp+0x08]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V07 tmp6         [V07,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
-;  V08 tmp7         [V08,T02] (  2,  2   )  ushort  ->  eax         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
+;  V05 tmp4         [V05,T05] (  2,  4   )   float  ->  mm0         "Inlining Arg"
+;  V06 tmp5         [V06,T04] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V07 tmp6         [V07,T00] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V08 tmp7         [V08,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V09 tmp8         [V09,T02] (  2,  2   )  ushort  ->  eax         V03._value(offs=0x00) P-INDEP "field V03._value (fldOffset=0x0)"
+;  V10 tmp9         [V10,T03] (  2,  2   )  ushort  ->  eax         V04._value(offs=0x00) P-INDEP "field V04._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x04]
 ;
 ; Lcl frame size = 4
@@ -13682,10 +13786,11 @@ RWD00  dd	7FFFFFFFh
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;  V01 tmp0         [V01,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V04 tmp3         [V04,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x04]
 ;
 ; Lcl frame size = 4
@@ -14127,10 +14232,11 @@ RWD640 dd	FFC00000h
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;  V01 tmp0         [V01,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V04 tmp3         [V04,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x04]
 ;
 ; Lcl frame size = 4
@@ -14173,10 +14279,11 @@ G_M48165_IG03:
 ; Final local variable assignments
 ;
 ;  V00 arg0         [V00    ] (  1,  1   )  struct ( 4) [ebp+0x08]  
-;  V01 tmp0         [V01,T00] (  2,  2   )   short  ->  eax         "Inline return value spill temp"
+;* V01 tmp0         [V01    ] (  0,  0   )  struct ( 4) zero-ref    "Inline return value spill temp"
 ;* V02 tmp1         [V02    ] (  0,  0   )  struct ( 4) zero-ref    "Inlining Arg"
-;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
-;  V04 tmp3         [V04,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
+;  V03 tmp2         [V03,T02] (  1,  1   )  ushort  ->  [ebp+0x08]   do-not-enreg[] V00._value(offs=0x00) P-DEP "field V00._value (fldOffset=0x0)"
+;  V04 tmp3         [V04,T00] (  2,  2   )  ushort  ->  eax         V01._value(offs=0x00) P-INDEP "field V01._value (fldOffset=0x0)"
+;  V05 tmp4         [V05,T01] (  2,  2   )  ushort  ->  eax         V02._value(offs=0x00) P-INDEP "field V02._value (fldOffset=0x0)"
 ;  TEMP_01                                   float  ->  [ebp-0x04]
 ;
 ; Lcl frame size = 4
@@ -15359,8 +15466,14 @@ G_M23493_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  1,  1   )   float  ->  [ebp+0x0C]  
-;  V01 arg1         [V01,T01] (  1,  1   )   float  ->  [ebp+0x08]  
+;  V00 arg0         [V00,T01] (  7,  3   )   float  ->  mm0        
+;  V01 arg1         [V01,T03] (  4,  2.25)   float  ->  mm1        
+;* V02 tmp0         [V02    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T02] (  5,  3   )   float  ->  mm1         "Inline return value spill temp"
+;  V05 tmp3         [V05,T00] (  2,  0.50)     int  ->  eax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V07 tmp5         [V07,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
 ;  TEMP_01                                   float  ->  [ebp-0x04]
 ;
 ; Lcl frame size = 4
@@ -15370,96 +15483,50 @@ G_M15612_IG01:
        mov      ebp, esp
        push     eax
        vzeroupper 
-						;; bbWeight=1    PerfScore 3.25
-G_M15612_IG02:
-       vmovss   xmm0, dword ptr [ebp+0CH]
-       sub      esp, 4
-       vmovss   dword ptr [esp], xmm0
-       vmovss   xmm0, dword ptr [ebp+08H]
-       sub      esp, 4
-       vmovss   dword ptr [esp], xmm0
-       call     Silk.NET.Maths.Scalar:Min(float,float):float
-       fstp     dword ptr [ebp-04H]
-       vmovss   xmm0, dword ptr [ebp-04H]
-       vmovss   dword ptr [ebp-04H], xmm0
-       fld      dword ptr [ebp-04H]
-						;; bbWeight=1    PerfScore 10.00
-G_M15612_IG03:
-       mov      esp, ebp
-       pop      ebp
-       ret      8
-						;; bbWeight=1    PerfScore 2.75
-
-; Total bytes of code 60, prolog size 7, PerfScore 22.60, (MethodHash=671dc303) for method JITTest.ScalarFloat:Min(float,float):float
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(float,float):float
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T01] (  7,  3   )   float  ->  mm0        
-;  V01 arg1         [V01,T03] (  4,  2.25)   float  ->  mm1        
-;* V02 tmp0         [V02    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
-;  V03 tmp1         [V03,T02] (  5,  3   )   float  ->  mm1         "Inline return value spill temp"
-;  V04 tmp2         [V04,T00] (  2,  0.50)     int  ->  eax         "Inline return value spill temp"
-;* V05 tmp3         [V05    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
-;  V06 tmp4         [V06,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
-;  TEMP_01                                   float  ->  [ebp-0x04]
-;
-; Lcl frame size = 4
-
-G_M50508_IG01:
-       push     ebp
-       mov      ebp, esp
-       push     eax
-       vzeroupper 
        vmovss   xmm0, dword ptr [ebp+0CH]
        vmovss   xmm1, dword ptr [ebp+08H]
 						;; bbWeight=1    PerfScore 7.25
-G_M50508_IG02:
+G_M15612_IG02:
        vucomiss xmm0, xmm1
-       jp       SHORT G_M50508_IG03
-       je       SHORT G_M50508_IG06
+       jp       SHORT G_M15612_IG03
+       je       SHORT G_M15612_IG06
 						;; bbWeight=1    PerfScore 3.00
-G_M50508_IG03:
+G_M15612_IG03:
        vucomiss xmm0, xmm0
-       jp       SHORT G_M50508_IG06
+       jp       SHORT G_M15612_IG06
        vucomiss xmm1, xmm0
-       ja       SHORT G_M50508_IG05
+       ja       SHORT G_M15612_IG05
 						;; bbWeight=0.25 PerfScore 1.00
-G_M50508_IG04:
-       jmp      SHORT G_M50508_IG09
+G_M15612_IG04:
+       jmp      SHORT G_M15612_IG09
 						;; bbWeight=0.50 PerfScore 1.00
-G_M50508_IG05:
+G_M15612_IG05:
        vmovaps  xmm1, xmm0
-       jmp      SHORT G_M50508_IG09
+       jmp      SHORT G_M15612_IG09
 						;; bbWeight=0.50 PerfScore 1.12
-G_M50508_IG06:
+G_M15612_IG06:
        vmovaps  xmm2, xmm0
        vmovd    eax, xmm2
        test     eax, eax
-       jl       SHORT G_M50508_IG08
+       jl       SHORT G_M15612_IG08
 						;; bbWeight=0.25 PerfScore 0.62
-G_M50508_IG07:
-       jmp      SHORT G_M50508_IG09
+G_M15612_IG07:
+       jmp      SHORT G_M15612_IG09
 						;; bbWeight=0.50 PerfScore 1.00
-G_M50508_IG08:
+G_M15612_IG08:
        vmovaps  xmm1, xmm0
 						;; bbWeight=0.50 PerfScore 0.12
-G_M50508_IG09:
+G_M15612_IG09:
        vmovss   dword ptr [ebp-04H], xmm1
        fld      dword ptr [ebp-04H]
 						;; bbWeight=1    PerfScore 1.00
-G_M50508_IG10:
+G_M15612_IG10:
        mov      esp, ebp
        pop      ebp
        ret      8
 						;; bbWeight=1    PerfScore 2.75
 
-; Total bytes of code 77, prolog size 7, PerfScore 27.58, (MethodHash=1de43ab3) for method Silk.NET.Maths.Scalar:Min(float,float):float
+; Total bytes of code 77, prolog size 7, PerfScore 27.58, (MethodHash=671dc303) for method JITTest.ScalarFloat:Min(float,float):float
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarFloat:Max(float,float):float
@@ -15469,8 +15536,14 @@ G_M50508_IG10:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  1,  1   )   float  ->  [ebp+0x0C]  
-;  V01 arg1         [V01,T01] (  1,  1   )   float  ->  [ebp+0x08]  
+;  V00 arg0         [V00,T02] (  7,  3.25)   float  ->  mm0        
+;  V01 arg1         [V01,T03] (  5,  2.50)   float  ->  mm1        
+;* V02 tmp0         [V02    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
+;* V03 tmp1         [V03    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T01] (  6,  3.50)   float  ->  mm1         "Inline return value spill temp"
+;  V05 tmp3         [V05,T00] (  2,  0.50)     int  ->  eax         "Inline return value spill temp"
+;* V06 tmp4         [V06    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V07 tmp5         [V07,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
 ;  TEMP_01                                   float  ->  [ebp-0x04]
 ;
 ; Lcl frame size = 4
@@ -15480,100 +15553,54 @@ G_M26530_IG01:
        mov      ebp, esp
        push     eax
        vzeroupper 
-						;; bbWeight=1    PerfScore 3.25
-G_M26530_IG02:
-       vmovss   xmm0, dword ptr [ebp+0CH]
-       sub      esp, 4
-       vmovss   dword ptr [esp], xmm0
-       vmovss   xmm0, dword ptr [ebp+08H]
-       sub      esp, 4
-       vmovss   dword ptr [esp], xmm0
-       call     Silk.NET.Maths.Scalar:Max(float,float):float
-       fstp     dword ptr [ebp-04H]
-       vmovss   xmm0, dword ptr [ebp-04H]
-       vmovss   dword ptr [ebp-04H], xmm0
-       fld      dword ptr [ebp-04H]
-						;; bbWeight=1    PerfScore 10.00
-G_M26530_IG03:
-       mov      esp, ebp
-       pop      ebp
-       ret      8
-						;; bbWeight=1    PerfScore 2.75
-
-; Total bytes of code 60, prolog size 7, PerfScore 22.60, (MethodHash=9671985d) for method JITTest.ScalarFloat:Max(float,float):float
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(float,float):float
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T02] (  7,  3.25)   float  ->  mm0        
-;  V01 arg1         [V01,T03] (  5,  2.50)   float  ->  mm1        
-;* V02 tmp0         [V02    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
-;  V03 tmp1         [V03,T01] (  6,  3.50)   float  ->  mm1         "Inline return value spill temp"
-;  V04 tmp2         [V04,T00] (  2,  0.50)     int  ->  eax         "Inline return value spill temp"
-;* V05 tmp3         [V05    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
-;  V06 tmp4         [V06,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
-;  TEMP_01                                   float  ->  [ebp-0x04]
-;
-; Lcl frame size = 4
-
-G_M9746_IG01:
-       push     ebp
-       mov      ebp, esp
-       push     eax
-       vzeroupper 
        vmovss   xmm0, dword ptr [ebp+0CH]
        vmovss   xmm1, dword ptr [ebp+08H]
 						;; bbWeight=1    PerfScore 7.25
-G_M9746_IG02:
+G_M26530_IG02:
        vucomiss xmm0, xmm1
-       jp       SHORT G_M9746_IG03
-       je       SHORT G_M9746_IG07
+       jp       SHORT G_M26530_IG03
+       je       SHORT G_M26530_IG07
 						;; bbWeight=1    PerfScore 3.00
-G_M9746_IG03:
+G_M26530_IG03:
        vucomiss xmm0, xmm0
-       jp       SHORT G_M9746_IG06
+       jp       SHORT G_M26530_IG06
        vucomiss xmm0, xmm1
-       ja       SHORT G_M9746_IG05
+       ja       SHORT G_M26530_IG05
 						;; bbWeight=0.25 PerfScore 1.00
-G_M9746_IG04:
-       jmp      SHORT G_M9746_IG10
+G_M26530_IG04:
+       jmp      SHORT G_M26530_IG10
 						;; bbWeight=0.50 PerfScore 1.00
-G_M9746_IG05:
+G_M26530_IG05:
        vmovaps  xmm1, xmm0
-       jmp      SHORT G_M9746_IG10
+       jmp      SHORT G_M26530_IG10
 						;; bbWeight=0.50 PerfScore 1.12
-G_M9746_IG06:
+G_M26530_IG06:
        vmovaps  xmm1, xmm0
-       jmp      SHORT G_M9746_IG10
+       jmp      SHORT G_M26530_IG10
 						;; bbWeight=0.50 PerfScore 1.12
-G_M9746_IG07:
+G_M26530_IG07:
        vmovaps  xmm2, xmm1
        vmovd    eax, xmm2
        test     eax, eax
-       jl       SHORT G_M9746_IG09
+       jl       SHORT G_M26530_IG09
 						;; bbWeight=0.25 PerfScore 0.62
-G_M9746_IG08:
-       jmp      SHORT G_M9746_IG10
+G_M26530_IG08:
+       jmp      SHORT G_M26530_IG10
 						;; bbWeight=0.50 PerfScore 1.00
-G_M9746_IG09:
+G_M26530_IG09:
        vmovaps  xmm1, xmm0
 						;; bbWeight=0.50 PerfScore 0.12
-G_M9746_IG10:
+G_M26530_IG10:
        vmovss   dword ptr [ebp-04H], xmm1
        fld      dword ptr [ebp-04H]
 						;; bbWeight=1    PerfScore 1.00
-G_M9746_IG11:
+G_M26530_IG11:
        mov      esp, ebp
        pop      ebp
        ret      8
 						;; bbWeight=1    PerfScore 2.75
 
-; Total bytes of code 83, prolog size 7, PerfScore 29.40, (MethodHash=ada7d9ed) for method Silk.NET.Maths.Scalar:Max(float,float):float
+; Total bytes of code 83, prolog size 7, PerfScore 29.40, (MethodHash=9671985d) for method JITTest.ScalarFloat:Max(float,float):float
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarFloat:Larger(float,float):bool
@@ -15758,6 +15785,148 @@ G_M12729_IG03:
 ; Total bytes of code 94, prolog size 7, PerfScore 33.40, (MethodHash=430fce46) for method JITTest.ScalarFloat:Clamp(float,float,float):float
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(float,float):float
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T02] (  7,  3.25)   float  ->  mm0        
+;  V01 arg1         [V01,T03] (  5,  2.50)   float  ->  mm1        
+;* V02 tmp0         [V02    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T01] (  6,  3.50)   float  ->  mm1         "Inline return value spill temp"
+;  V04 tmp2         [V04,T00] (  2,  0.50)     int  ->  eax         "Inline return value spill temp"
+;* V05 tmp3         [V05    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V06 tmp4         [V06,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
+;  TEMP_01                                   float  ->  [ebp-0x04]
+;
+; Lcl frame size = 4
+
+G_M9746_IG01:
+       push     ebp
+       mov      ebp, esp
+       push     eax
+       vzeroupper 
+       vmovss   xmm0, dword ptr [ebp+0CH]
+       vmovss   xmm1, dword ptr [ebp+08H]
+						;; bbWeight=1    PerfScore 7.25
+G_M9746_IG02:
+       vucomiss xmm0, xmm1
+       jp       SHORT G_M9746_IG03
+       je       SHORT G_M9746_IG07
+						;; bbWeight=1    PerfScore 3.00
+G_M9746_IG03:
+       vucomiss xmm0, xmm0
+       jp       SHORT G_M9746_IG06
+       vucomiss xmm0, xmm1
+       ja       SHORT G_M9746_IG05
+						;; bbWeight=0.25 PerfScore 1.00
+G_M9746_IG04:
+       jmp      SHORT G_M9746_IG10
+						;; bbWeight=0.50 PerfScore 1.00
+G_M9746_IG05:
+       vmovaps  xmm1, xmm0
+       jmp      SHORT G_M9746_IG10
+						;; bbWeight=0.50 PerfScore 1.12
+G_M9746_IG06:
+       vmovaps  xmm1, xmm0
+       jmp      SHORT G_M9746_IG10
+						;; bbWeight=0.50 PerfScore 1.12
+G_M9746_IG07:
+       vmovaps  xmm2, xmm1
+       vmovd    eax, xmm2
+       test     eax, eax
+       jl       SHORT G_M9746_IG09
+						;; bbWeight=0.25 PerfScore 0.62
+G_M9746_IG08:
+       jmp      SHORT G_M9746_IG10
+						;; bbWeight=0.50 PerfScore 1.00
+G_M9746_IG09:
+       vmovaps  xmm1, xmm0
+						;; bbWeight=0.50 PerfScore 0.12
+G_M9746_IG10:
+       vmovss   dword ptr [ebp-04H], xmm1
+       fld      dword ptr [ebp-04H]
+						;; bbWeight=1    PerfScore 1.00
+G_M9746_IG11:
+       mov      esp, ebp
+       pop      ebp
+       ret      8
+						;; bbWeight=1    PerfScore 2.75
+
+; Total bytes of code 83, prolog size 7, PerfScore 29.40, (MethodHash=ada7d9ed) for method Silk.NET.Maths.Scalar:Max(float,float):float
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(float,float):float
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T01] (  7,  3   )   float  ->  mm0        
+;  V01 arg1         [V01,T03] (  4,  2.25)   float  ->  mm1        
+;* V02 tmp0         [V02    ] (  0,  0   )   float  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T02] (  5,  3   )   float  ->  mm1         "Inline return value spill temp"
+;  V04 tmp2         [V04,T00] (  2,  0.50)     int  ->  eax         "Inline return value spill temp"
+;* V05 tmp3         [V05    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op "Inlining Arg"
+;  V06 tmp4         [V06,T04] (  2,  0.50)  simd16  ->  mm2         "Inline stloc first use temp"
+;  TEMP_01                                   float  ->  [ebp-0x04]
+;
+; Lcl frame size = 4
+
+G_M50508_IG01:
+       push     ebp
+       mov      ebp, esp
+       push     eax
+       vzeroupper 
+       vmovss   xmm0, dword ptr [ebp+0CH]
+       vmovss   xmm1, dword ptr [ebp+08H]
+						;; bbWeight=1    PerfScore 7.25
+G_M50508_IG02:
+       vucomiss xmm0, xmm1
+       jp       SHORT G_M50508_IG03
+       je       SHORT G_M50508_IG06
+						;; bbWeight=1    PerfScore 3.00
+G_M50508_IG03:
+       vucomiss xmm0, xmm0
+       jp       SHORT G_M50508_IG06
+       vucomiss xmm1, xmm0
+       ja       SHORT G_M50508_IG05
+						;; bbWeight=0.25 PerfScore 1.00
+G_M50508_IG04:
+       jmp      SHORT G_M50508_IG09
+						;; bbWeight=0.50 PerfScore 1.00
+G_M50508_IG05:
+       vmovaps  xmm1, xmm0
+       jmp      SHORT G_M50508_IG09
+						;; bbWeight=0.50 PerfScore 1.12
+G_M50508_IG06:
+       vmovaps  xmm2, xmm0
+       vmovd    eax, xmm2
+       test     eax, eax
+       jl       SHORT G_M50508_IG08
+						;; bbWeight=0.25 PerfScore 0.62
+G_M50508_IG07:
+       jmp      SHORT G_M50508_IG09
+						;; bbWeight=0.50 PerfScore 1.00
+G_M50508_IG08:
+       vmovaps  xmm1, xmm0
+						;; bbWeight=0.50 PerfScore 0.12
+G_M50508_IG09:
+       vmovss   dword ptr [ebp-04H], xmm1
+       fld      dword ptr [ebp-04H]
+						;; bbWeight=1    PerfScore 1.00
+G_M50508_IG10:
+       mov      esp, ebp
+       pop      ebp
+       ret      8
+						;; bbWeight=1    PerfScore 2.75
+
+; Total bytes of code 77, prolog size 7, PerfScore 27.58, (MethodHash=1de43ab3) for method Silk.NET.Maths.Scalar:Min(float,float):float
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarFloat:Negate(float):float
 ; Emitting BLENDED_CODE for generic X86 CPU - Windows
 ; optimized code
@@ -15765,7 +15934,8 @@ G_M12729_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  1,  1   )   float  ->  [ebp+0x08]  
+;  V00 arg0         [V00,T01] (  1,  1   )   float  ->  [ebp+0x08]  
+;  V01 tmp0         [V01,T00] (  2,  2   )   float  ->  mm0         "Inline return value spill temp"
 ;  TEMP_01                                   float  ->  [ebp-0x04]
 ;
 ; Lcl frame size = 4
@@ -15777,51 +15947,13 @@ G_M20150_IG01:
        vzeroupper 
 						;; bbWeight=1    PerfScore 3.25
 G_M20150_IG02:
-       vmovss   xmm0, dword ptr [ebp+08H]
-       sub      esp, 4
-       vmovss   dword ptr [esp], xmm0
-       call     Silk.NET.Maths.Scalar:Negate(float):float
-       fstp     dword ptr [ebp-04H]
-       vmovss   xmm0, dword ptr [ebp-04H]
-       vmovss   dword ptr [ebp-04H], xmm0
-       fld      dword ptr [ebp-04H]
-						;; bbWeight=1    PerfScore 7.25
-G_M20150_IG03:
-       mov      esp, ebp
-       pop      ebp
-       ret      4
-						;; bbWeight=1    PerfScore 2.75
-
-; Total bytes of code 47, prolog size 7, PerfScore 18.35, (MethodHash=50f9b149) for method JITTest.ScalarFloat:Negate(float):float
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(float):float
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  1,  1   )   float  ->  [ebp+0x08]  
-;* V01 loc0         [V01    ] (  0,  0   )   float  ->  zero-ref    ld-addr-op
-;  TEMP_01                                   float  ->  [ebp-0x04]
-;
-; Lcl frame size = 4
-
-G_M40518_IG01:
-       push     ebp
-       mov      ebp, esp
-       push     eax
-       vzeroupper 
-						;; bbWeight=1    PerfScore 3.25
-G_M40518_IG02:
        vmovss   xmm1, dword ptr [ebp+08H]
        vmovss   xmm0, dword ptr [@RWD00]
        vxorps   xmm0, xmm1
        vmovss   dword ptr [ebp-04H], xmm0
        fld      dword ptr [ebp-04H]
 						;; bbWeight=1    PerfScore 5.33
-G_M40518_IG03:
+G_M20150_IG03:
        mov      esp, ebp
        pop      ebp
        ret      4
@@ -15829,7 +15961,7 @@ G_M40518_IG03:
 RWD00  dd	80000000h
 
 
-; Total bytes of code 38, prolog size 7, PerfScore 15.53, (MethodHash=c9b261b9) for method Silk.NET.Maths.Scalar:Negate(float):float
+; Total bytes of code 38, prolog size 7, PerfScore 15.53, (MethodHash=50f9b149) for method JITTest.ScalarFloat:Negate(float):float
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarFloat:Equal(float,float):bool
@@ -17214,60 +17346,20 @@ G_M43461_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  1,  1   )  double  ->  [ebp+0x10]  
-;  V01 arg1         [V01,T01] (  1,  1   )  double  ->  [ebp+0x08]  
-;  TEMP_01                                  double  ->  [ebp-0x08]
-;
-; Lcl frame size = 8
-
-G_M43772_IG01:
-       push     ebp
-       mov      ebp, esp
-       sub      esp, 8
-       vzeroupper 
-						;; bbWeight=1    PerfScore 2.50
-G_M43772_IG02:
-       vmovsd   xmm0, qword ptr [ebp+10H]
-       sub      esp, 8
-       vmovsd   qword ptr [esp], xmm0
-       vmovsd   xmm0, qword ptr [ebp+08H]
-       sub      esp, 8
-       vmovsd   qword ptr [esp], xmm0
-       call     Silk.NET.Maths.Scalar:Min(double,double):double
-       fstp     qword ptr [ebp-08H]
-       vmovsd   xmm0, qword ptr [ebp-08H]
-       vmovsd   qword ptr [ebp-08H], xmm0
-       fld      qword ptr [ebp-08H]
-						;; bbWeight=1    PerfScore 10.00
-G_M43772_IG03:
-       mov      esp, ebp
-       pop      ebp
-       ret      16
-						;; bbWeight=1    PerfScore 2.75
-
-; Total bytes of code 62, prolog size 9, PerfScore 22.05, (MethodHash=a5dd5503) for method JITTest.ScalarDouble:Min(double,double):double
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Min(double,double):double
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00,T02] (  7,  3   )  double  ->  mm0        
 ;  V01 arg1         [V01,T04] (  4,  2.25)  double  ->  mm1        
 ;* V02 tmp0         [V02    ] (  0,  0   )  double  ->  zero-ref    "Inline return value spill temp"
-;  V03 tmp1         [V03,T03] (  5,  3   )  double  ->  mm1         "Inline return value spill temp"
-;* V04 tmp2         [V04    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V05 tmp3         [V05,T05] (  2,  1   )  double  ->  [ebp-0x08]   do-not-enreg[F] ld-addr-op "Inlining Arg"
-;* V06 rat0         [V06,T01] (  0,  0   )     int  ->  zero-ref    V04.lo(offs=0x00) "field V04.lo (fldOffset=0x0)"
-;  V07 rat1         [V07,T00] (  2,  0.50)     int  ->  eax         V04.hi(offs=0x04) "field V04.hi (fldOffset=0x4)"
+;* V03 tmp1         [V03    ] (  0,  0   )  double  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T03] (  5,  3   )  double  ->  mm1         "Inline return value spill temp"
+;* V05 tmp3         [V05    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V06 tmp4         [V06,T05] (  2,  1   )  double  ->  [ebp-0x08]   do-not-enreg[F] ld-addr-op "Inlining Arg"
+;* V07 rat0         [V07,T01] (  0,  0   )     int  ->  zero-ref    V05.lo(offs=0x00) "field V05.lo (fldOffset=0x0)"
+;  V08 rat1         [V08,T00] (  2,  0.50)     int  ->  eax         V05.hi(offs=0x04) "field V05.hi (fldOffset=0x4)"
 ;  TEMP_01                                  double  ->  [ebp-0x10]
 ;
 ; Lcl frame size = 16
 
-G_M52969_IG01:
+G_M43772_IG01:
        push     ebp
        mov      ebp, esp
        sub      esp, 16
@@ -17275,47 +17367,47 @@ G_M52969_IG01:
        vmovsd   xmm0, qword ptr [ebp+10H]
        vmovsd   xmm1, qword ptr [ebp+08H]
 						;; bbWeight=1    PerfScore 6.50
-G_M52969_IG02:
+G_M43772_IG02:
        vucomisd xmm0, xmm1
-       jp       SHORT G_M52969_IG03
-       je       SHORT G_M52969_IG06
+       jp       SHORT G_M43772_IG03
+       je       SHORT G_M43772_IG06
 						;; bbWeight=1    PerfScore 3.00
-G_M52969_IG03:
+G_M43772_IG03:
        vucomisd xmm0, xmm0
-       jp       SHORT G_M52969_IG06
+       jp       SHORT G_M43772_IG06
        vucomisd xmm1, xmm0
-       ja       SHORT G_M52969_IG05
+       ja       SHORT G_M43772_IG05
 						;; bbWeight=0.25 PerfScore 1.00
-G_M52969_IG04:
-       jmp      SHORT G_M52969_IG09
+G_M43772_IG04:
+       jmp      SHORT G_M43772_IG09
 						;; bbWeight=0.50 PerfScore 1.00
-G_M52969_IG05:
+G_M43772_IG05:
        vmovaps  xmm1, xmm0
-       jmp      SHORT G_M52969_IG09
+       jmp      SHORT G_M43772_IG09
 						;; bbWeight=0.50 PerfScore 1.12
-G_M52969_IG06:
+G_M43772_IG06:
        vmovsd   qword ptr [ebp-08H], xmm0
        mov      eax, dword ptr [ebp-04H]
        test     eax, eax
-       jl       SHORT G_M52969_IG08
+       jl       SHORT G_M43772_IG08
 						;; bbWeight=0.25 PerfScore 0.69
-G_M52969_IG07:
-       jmp      SHORT G_M52969_IG09
+G_M43772_IG07:
+       jmp      SHORT G_M43772_IG09
 						;; bbWeight=0.50 PerfScore 1.00
-G_M52969_IG08:
+G_M43772_IG08:
        vmovaps  xmm1, xmm0
 						;; bbWeight=0.50 PerfScore 0.12
-G_M52969_IG09:
+G_M43772_IG09:
        vmovsd   qword ptr [ebp-10H], xmm1
        fld      qword ptr [ebp-10H]
 						;; bbWeight=1    PerfScore 1.00
-G_M52969_IG10:
+G_M43772_IG10:
        mov      esp, ebp
        pop      ebp
        ret      16
 						;; bbWeight=1    PerfScore 2.75
 
-; Total bytes of code 79, prolog size 9, PerfScore 26.99, (MethodHash=4bad3116) for method Silk.NET.Maths.Scalar:Min(double,double):double
+; Total bytes of code 79, prolog size 9, PerfScore 26.99, (MethodHash=a5dd5503) for method JITTest.ScalarDouble:Min(double,double):double
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarDouble:Max(double,double):double
@@ -17325,60 +17417,20 @@ G_M52969_IG10:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  1,  1   )  double  ->  [ebp+0x10]  
-;  V01 arg1         [V01,T01] (  1,  1   )  double  ->  [ebp+0x08]  
-;  TEMP_01                                  double  ->  [ebp-0x08]
-;
-; Lcl frame size = 8
-
-G_M44770_IG01:
-       push     ebp
-       mov      ebp, esp
-       sub      esp, 8
-       vzeroupper 
-						;; bbWeight=1    PerfScore 2.50
-G_M44770_IG02:
-       vmovsd   xmm0, qword ptr [ebp+10H]
-       sub      esp, 8
-       vmovsd   qword ptr [esp], xmm0
-       vmovsd   xmm0, qword ptr [ebp+08H]
-       sub      esp, 8
-       vmovsd   qword ptr [esp], xmm0
-       call     Silk.NET.Maths.Scalar:Max(double,double):double
-       fstp     qword ptr [ebp-08H]
-       vmovsd   xmm0, qword ptr [ebp-08H]
-       vmovsd   qword ptr [ebp-08H], xmm0
-       fld      qword ptr [ebp-08H]
-						;; bbWeight=1    PerfScore 10.00
-G_M44770_IG03:
-       mov      esp, ebp
-       pop      ebp
-       ret      16
-						;; bbWeight=1    PerfScore 2.75
-
-; Total bytes of code 62, prolog size 9, PerfScore 22.05, (MethodHash=ad4d511d) for method JITTest.ScalarDouble:Max(double,double):double
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Max(double,double):double
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
 ;  V00 arg0         [V00,T03] (  7,  3.25)  double  ->  mm0        
 ;  V01 arg1         [V01,T04] (  5,  2.50)  double  ->  mm1        
 ;* V02 tmp0         [V02    ] (  0,  0   )  double  ->  zero-ref    "Inline return value spill temp"
-;  V03 tmp1         [V03,T02] (  6,  3.50)  double  ->  mm1         "Inline return value spill temp"
-;* V04 tmp2         [V04    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
-;  V05 tmp3         [V05,T05] (  2,  1   )  double  ->  [ebp-0x08]   do-not-enreg[F] ld-addr-op "Inlining Arg"
-;* V06 rat0         [V06,T01] (  0,  0   )     int  ->  zero-ref    V04.lo(offs=0x00) "field V04.lo (fldOffset=0x0)"
-;  V07 rat1         [V07,T00] (  2,  0.50)     int  ->  eax         V04.hi(offs=0x04) "field V04.hi (fldOffset=0x4)"
+;* V03 tmp1         [V03    ] (  0,  0   )  double  ->  zero-ref    "Inline return value spill temp"
+;  V04 tmp2         [V04,T02] (  6,  3.50)  double  ->  mm1         "Inline return value spill temp"
+;* V05 tmp3         [V05    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V06 tmp4         [V06,T05] (  2,  1   )  double  ->  [ebp-0x08]   do-not-enreg[F] ld-addr-op "Inlining Arg"
+;* V07 rat0         [V07,T01] (  0,  0   )     int  ->  zero-ref    V05.lo(offs=0x00) "field V05.lo (fldOffset=0x0)"
+;  V08 rat1         [V08,T00] (  2,  0.50)     int  ->  eax         V05.hi(offs=0x04) "field V05.hi (fldOffset=0x4)"
 ;  TEMP_01                                  double  ->  [ebp-0x10]
 ;
 ; Lcl frame size = 16
 
-G_M47351_IG01:
+G_M44770_IG01:
        push     ebp
        mov      ebp, esp
        sub      esp, 16
@@ -17386,51 +17438,51 @@ G_M47351_IG01:
        vmovsd   xmm0, qword ptr [ebp+10H]
        vmovsd   xmm1, qword ptr [ebp+08H]
 						;; bbWeight=1    PerfScore 6.50
-G_M47351_IG02:
+G_M44770_IG02:
        vucomisd xmm0, xmm1
-       jp       SHORT G_M47351_IG03
-       je       SHORT G_M47351_IG07
+       jp       SHORT G_M44770_IG03
+       je       SHORT G_M44770_IG07
 						;; bbWeight=1    PerfScore 3.00
-G_M47351_IG03:
+G_M44770_IG03:
        vucomisd xmm0, xmm0
-       jp       SHORT G_M47351_IG06
+       jp       SHORT G_M44770_IG06
        vucomisd xmm0, xmm1
-       ja       SHORT G_M47351_IG05
+       ja       SHORT G_M44770_IG05
 						;; bbWeight=0.25 PerfScore 1.00
-G_M47351_IG04:
-       jmp      SHORT G_M47351_IG10
+G_M44770_IG04:
+       jmp      SHORT G_M44770_IG10
 						;; bbWeight=0.50 PerfScore 1.00
-G_M47351_IG05:
+G_M44770_IG05:
        vmovaps  xmm1, xmm0
-       jmp      SHORT G_M47351_IG10
+       jmp      SHORT G_M44770_IG10
 						;; bbWeight=0.50 PerfScore 1.12
-G_M47351_IG06:
+G_M44770_IG06:
        vmovaps  xmm1, xmm0
-       jmp      SHORT G_M47351_IG10
+       jmp      SHORT G_M44770_IG10
 						;; bbWeight=0.50 PerfScore 1.12
-G_M47351_IG07:
+G_M44770_IG07:
        vmovsd   qword ptr [ebp-08H], xmm1
        mov      eax, dword ptr [ebp-04H]
        test     eax, eax
-       jl       SHORT G_M47351_IG09
+       jl       SHORT G_M44770_IG09
 						;; bbWeight=0.25 PerfScore 0.69
-G_M47351_IG08:
-       jmp      SHORT G_M47351_IG10
+G_M44770_IG08:
+       jmp      SHORT G_M44770_IG10
 						;; bbWeight=0.50 PerfScore 1.00
-G_M47351_IG09:
+G_M44770_IG09:
        vmovaps  xmm1, xmm0
 						;; bbWeight=0.50 PerfScore 0.12
-G_M47351_IG10:
+G_M44770_IG10:
        vmovsd   qword ptr [ebp-10H], xmm1
        fld      qword ptr [ebp-10H]
 						;; bbWeight=1    PerfScore 1.00
-G_M47351_IG11:
+G_M44770_IG11:
        mov      esp, ebp
        pop      ebp
        ret      16
 						;; bbWeight=1    PerfScore 2.75
 
-; Total bytes of code 85, prolog size 9, PerfScore 28.81, (MethodHash=b0584708) for method Silk.NET.Maths.Scalar:Max(double,double):double
+; Total bytes of code 85, prolog size 9, PerfScore 28.81, (MethodHash=ad4d511d) for method JITTest.ScalarDouble:Max(double,double):double
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarDouble:Larger(double,double):bool
@@ -17615,6 +17667,150 @@ G_M49084_IG03:
 ; Total bytes of code 96, prolog size 9, PerfScore 32.85, (MethodHash=95794043) for method JITTest.ScalarDouble:Clamp(double,double,double):double
 ; ============================================================
 
+; Assembly listing for method Silk.NET.Maths.Scalar:Max(double,double):double
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T03] (  7,  3.25)  double  ->  mm0        
+;  V01 arg1         [V01,T04] (  5,  2.50)  double  ->  mm1        
+;* V02 tmp0         [V02    ] (  0,  0   )  double  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T02] (  6,  3.50)  double  ->  mm1         "Inline return value spill temp"
+;* V04 tmp2         [V04    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V05 tmp3         [V05,T05] (  2,  1   )  double  ->  [ebp-0x08]   do-not-enreg[F] ld-addr-op "Inlining Arg"
+;* V06 rat0         [V06,T01] (  0,  0   )     int  ->  zero-ref    V04.lo(offs=0x00) "field V04.lo (fldOffset=0x0)"
+;  V07 rat1         [V07,T00] (  2,  0.50)     int  ->  eax         V04.hi(offs=0x04) "field V04.hi (fldOffset=0x4)"
+;  TEMP_01                                  double  ->  [ebp-0x10]
+;
+; Lcl frame size = 16
+
+G_M47351_IG01:
+       push     ebp
+       mov      ebp, esp
+       sub      esp, 16
+       vzeroupper 
+       vmovsd   xmm0, qword ptr [ebp+10H]
+       vmovsd   xmm1, qword ptr [ebp+08H]
+						;; bbWeight=1    PerfScore 6.50
+G_M47351_IG02:
+       vucomisd xmm0, xmm1
+       jp       SHORT G_M47351_IG03
+       je       SHORT G_M47351_IG07
+						;; bbWeight=1    PerfScore 3.00
+G_M47351_IG03:
+       vucomisd xmm0, xmm0
+       jp       SHORT G_M47351_IG06
+       vucomisd xmm0, xmm1
+       ja       SHORT G_M47351_IG05
+						;; bbWeight=0.25 PerfScore 1.00
+G_M47351_IG04:
+       jmp      SHORT G_M47351_IG10
+						;; bbWeight=0.50 PerfScore 1.00
+G_M47351_IG05:
+       vmovaps  xmm1, xmm0
+       jmp      SHORT G_M47351_IG10
+						;; bbWeight=0.50 PerfScore 1.12
+G_M47351_IG06:
+       vmovaps  xmm1, xmm0
+       jmp      SHORT G_M47351_IG10
+						;; bbWeight=0.50 PerfScore 1.12
+G_M47351_IG07:
+       vmovsd   qword ptr [ebp-08H], xmm1
+       mov      eax, dword ptr [ebp-04H]
+       test     eax, eax
+       jl       SHORT G_M47351_IG09
+						;; bbWeight=0.25 PerfScore 0.69
+G_M47351_IG08:
+       jmp      SHORT G_M47351_IG10
+						;; bbWeight=0.50 PerfScore 1.00
+G_M47351_IG09:
+       vmovaps  xmm1, xmm0
+						;; bbWeight=0.50 PerfScore 0.12
+G_M47351_IG10:
+       vmovsd   qword ptr [ebp-10H], xmm1
+       fld      qword ptr [ebp-10H]
+						;; bbWeight=1    PerfScore 1.00
+G_M47351_IG11:
+       mov      esp, ebp
+       pop      ebp
+       ret      16
+						;; bbWeight=1    PerfScore 2.75
+
+; Total bytes of code 85, prolog size 9, PerfScore 28.81, (MethodHash=b0584708) for method Silk.NET.Maths.Scalar:Max(double,double):double
+; ============================================================
+
+; Assembly listing for method Silk.NET.Maths.Scalar:Min(double,double):double
+; Emitting BLENDED_CODE for generic X86 CPU - Windows
+; optimized code
+; ebp based frame
+; partially interruptible
+; Final local variable assignments
+;
+;  V00 arg0         [V00,T02] (  7,  3   )  double  ->  mm0        
+;  V01 arg1         [V01,T04] (  4,  2.25)  double  ->  mm1        
+;* V02 tmp0         [V02    ] (  0,  0   )  double  ->  zero-ref    "Inline return value spill temp"
+;  V03 tmp1         [V03,T03] (  5,  3   )  double  ->  mm1         "Inline return value spill temp"
+;* V04 tmp2         [V04    ] (  0,  0   )    long  ->  zero-ref    "Inline return value spill temp"
+;  V05 tmp3         [V05,T05] (  2,  1   )  double  ->  [ebp-0x08]   do-not-enreg[F] ld-addr-op "Inlining Arg"
+;* V06 rat0         [V06,T01] (  0,  0   )     int  ->  zero-ref    V04.lo(offs=0x00) "field V04.lo (fldOffset=0x0)"
+;  V07 rat1         [V07,T00] (  2,  0.50)     int  ->  eax         V04.hi(offs=0x04) "field V04.hi (fldOffset=0x4)"
+;  TEMP_01                                  double  ->  [ebp-0x10]
+;
+; Lcl frame size = 16
+
+G_M52969_IG01:
+       push     ebp
+       mov      ebp, esp
+       sub      esp, 16
+       vzeroupper 
+       vmovsd   xmm0, qword ptr [ebp+10H]
+       vmovsd   xmm1, qword ptr [ebp+08H]
+						;; bbWeight=1    PerfScore 6.50
+G_M52969_IG02:
+       vucomisd xmm0, xmm1
+       jp       SHORT G_M52969_IG03
+       je       SHORT G_M52969_IG06
+						;; bbWeight=1    PerfScore 3.00
+G_M52969_IG03:
+       vucomisd xmm0, xmm0
+       jp       SHORT G_M52969_IG06
+       vucomisd xmm1, xmm0
+       ja       SHORT G_M52969_IG05
+						;; bbWeight=0.25 PerfScore 1.00
+G_M52969_IG04:
+       jmp      SHORT G_M52969_IG09
+						;; bbWeight=0.50 PerfScore 1.00
+G_M52969_IG05:
+       vmovaps  xmm1, xmm0
+       jmp      SHORT G_M52969_IG09
+						;; bbWeight=0.50 PerfScore 1.12
+G_M52969_IG06:
+       vmovsd   qword ptr [ebp-08H], xmm0
+       mov      eax, dword ptr [ebp-04H]
+       test     eax, eax
+       jl       SHORT G_M52969_IG08
+						;; bbWeight=0.25 PerfScore 0.69
+G_M52969_IG07:
+       jmp      SHORT G_M52969_IG09
+						;; bbWeight=0.50 PerfScore 1.00
+G_M52969_IG08:
+       vmovaps  xmm1, xmm0
+						;; bbWeight=0.50 PerfScore 0.12
+G_M52969_IG09:
+       vmovsd   qword ptr [ebp-10H], xmm1
+       fld      qword ptr [ebp-10H]
+						;; bbWeight=1    PerfScore 1.00
+G_M52969_IG10:
+       mov      esp, ebp
+       pop      ebp
+       ret      16
+						;; bbWeight=1    PerfScore 2.75
+
+; Total bytes of code 79, prolog size 9, PerfScore 26.99, (MethodHash=4bad3116) for method Silk.NET.Maths.Scalar:Min(double,double):double
+; ============================================================
+
 ; Assembly listing for method JITTest.ScalarDouble:Negate(double):double
 ; Emitting BLENDED_CODE for generic X86 CPU - Windows
 ; optimized code
@@ -17622,7 +17818,8 @@ G_M49084_IG03:
 ; partially interruptible
 ; Final local variable assignments
 ;
-;  V00 arg0         [V00,T00] (  1,  1   )  double  ->  [ebp+0x08]  
+;  V00 arg0         [V00,T01] (  1,  1   )  double  ->  [ebp+0x08]  
+;  V01 tmp0         [V01,T00] (  2,  2   )  double  ->  mm0         "Inline return value spill temp"
 ;  TEMP_01                                  double  ->  [ebp-0x08]
 ;
 ; Lcl frame size = 8
@@ -17634,51 +17831,13 @@ G_M14451_IG01:
        vzeroupper 
 						;; bbWeight=1    PerfScore 2.50
 G_M14451_IG02:
-       vmovsd   xmm0, qword ptr [ebp+08H]
-       sub      esp, 8
-       vmovsd   qword ptr [esp], xmm0
-       call     Silk.NET.Maths.Scalar:Negate(double):double
-       fstp     qword ptr [ebp-08H]
-       vmovsd   xmm0, qword ptr [ebp-08H]
-       vmovsd   qword ptr [ebp-08H], xmm0
-       fld      qword ptr [ebp-08H]
-						;; bbWeight=1    PerfScore 7.25
-G_M14451_IG03:
-       mov      esp, ebp
-       pop      ebp
-       ret      8
-						;; bbWeight=1    PerfScore 2.75
-
-; Total bytes of code 49, prolog size 9, PerfScore 17.80, (MethodHash=2b35c78c) for method JITTest.ScalarDouble:Negate(double):double
-; ============================================================
-
-; Assembly listing for method Silk.NET.Maths.Scalar:Negate(double):double
-; Emitting BLENDED_CODE for generic X86 CPU - Windows
-; optimized code
-; ebp based frame
-; partially interruptible
-; Final local variable assignments
-;
-;  V00 arg0         [V00,T00] (  1,  1   )  double  ->  [ebp+0x08]  
-;* V01 loc0         [V01    ] (  0,  0   )  double  ->  zero-ref    ld-addr-op
-;  TEMP_01                                  double  ->  [ebp-0x08]
-;
-; Lcl frame size = 8
-
-G_M6886_IG01:
-       push     ebp
-       mov      ebp, esp
-       sub      esp, 8
-       vzeroupper 
-						;; bbWeight=1    PerfScore 2.50
-G_M6886_IG02:
        vmovsd   xmm1, qword ptr [ebp+08H]
        vmovsd   xmm0, qword ptr [@RWD08]
        vxorps   xmm0, xmm1
        vmovsd   qword ptr [ebp-08H], xmm0
        fld      qword ptr [ebp-08H]
 						;; bbWeight=1    PerfScore 5.33
-G_M6886_IG03:
+G_M14451_IG03:
        mov      esp, ebp
        pop      ebp
        ret      8
@@ -17687,7 +17846,7 @@ RWD00  dq	0000000000000000h
 RWD08  dq	8000000000000000h
 
 
-; Total bytes of code 40, prolog size 9, PerfScore 14.98, (MethodHash=38f1e519) for method Silk.NET.Maths.Scalar:Negate(double):double
+; Total bytes of code 40, prolog size 9, PerfScore 14.98, (MethodHash=2b35c78c) for method JITTest.ScalarDouble:Negate(double):double
 ; ============================================================
 
 ; Assembly listing for method JITTest.ScalarDouble:Equal(double,double):bool

--- a/src/Lab/GenericMaths/GenericMaths.csproj
+++ b/src/Lab/GenericMaths/GenericMaths.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <ProjectReference Include="..\GenericMathsGenerator\GenericMathsGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\..\Maths\Silk.NET.Maths.GenericsGenerator\Silk.NET.Maths.GenericsGenerator.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
 
 </Project>

--- a/src/Lab/GenericMaths/Program.cs
+++ b/src/Lab/GenericMaths/Program.cs
@@ -10,6 +10,7 @@ namespace GenericMaths
         }
     }
 
+    [GenericMaths]
     public struct TypeSpecialization
     {
         public float Field;

--- a/src/Lab/GenericMaths/Program.cs
+++ b/src/Lab/GenericMaths/Program.cs
@@ -9,4 +9,18 @@ namespace GenericMaths
         {
         }
     }
+
+    public struct TypeSpecialization
+    {
+        public float Field;
+        public float Property { get; set; }
+
+        public float Method()
+        {
+            var a = Field + Property;
+            var b = 5 + 5;
+            var c = a + b;
+            return c * c;
+        }
+    }
 }

--- a/src/Maths/Silk.NET.Maths.GenericsGenerator/OperationWalker.cs
+++ b/src/Maths/Silk.NET.Maths.GenericsGenerator/OperationWalker.cs
@@ -91,8 +91,8 @@ namespace GenericMathsGenerator
             for (var index = 0; index < _localReferences.Count; index++)
             {
                 var localReference = _localReferences[index];
-                localReference.LocalVariable = _locals[localReference.OriginalName];
-                _locals[localReference.OriginalName].References.Add(localReference);
+                localReference.LocalVariable = _locals[localReference.Name];
+                _locals[localReference.Name].References.Add(localReference);
                 _localReferences[index] = localReference;
             }
         }

--- a/src/Maths/Silk.NET.Maths.GenericsGenerator/ValueTypes/BinaryOperatorValue.cs
+++ b/src/Maths/Silk.NET.Maths.GenericsGenerator/ValueTypes/BinaryOperatorValue.cs
@@ -45,7 +45,7 @@ namespace GenericMathsGenerator
         public int Step => _step.Value;
 
         public ExpressionSyntax BuildExpression
-            (ImmutableArray<ExpressionSyntax> children, ref List<StatementSyntax> statements, TargetType targetType)
+            (IBodyBuilder bodyBuilder, ImmutableArray<ExpressionSyntax> children)
         {
             Debug.Assert(children.Length == 2);
             return SyntaxFactory.BinaryExpression(OpSyntaxKind, children[0], children[1]);

--- a/src/Maths/Silk.NET.Maths.GenericsGenerator/ValueTypes/FieldReferenceValue.cs
+++ b/src/Maths/Silk.NET.Maths.GenericsGenerator/ValueTypes/FieldReferenceValue.cs
@@ -35,7 +35,8 @@ namespace GenericMathsGenerator.ValueTypes
 
         public int Step => 0;
 
-        public ExpressionSyntax BuildExpression(ImmutableArray<ExpressionSyntax> children, ref List<StatementSyntax> statements, TargetType type)
+        public ExpressionSyntax BuildExpression
+            (IBodyBuilder bodyBuilder, ImmutableArray<ExpressionSyntax> children)
         {
             return CastExpression(PredefinedType(Token(SyntaxKind.ObjectKeyword)), IdentifierName(Name));
         }

--- a/src/Maths/Silk.NET.Maths.GenericsGenerator/ValueTypes/LiteralValue.cs
+++ b/src/Maths/Silk.NET.Maths.GenericsGenerator/ValueTypes/LiteralValue.cs
@@ -39,10 +39,12 @@ namespace GenericMathsGenerator.ValueTypes
         public int Step => 0;
 
         public ExpressionSyntax BuildExpression
-            (ImmutableArray<ExpressionSyntax> children, ref List<StatementSyntax> statements, TargetType targetType)
-            => LiteralExpression
+            (IBodyBuilder bodyBuilder, ImmutableArray<ExpressionSyntax> children)
+        {
+            Debug.Assert(children.Length == 0);
+            return LiteralExpression
             (
-                SyntaxKind.NumericLiteralExpression, targetType switch
+                SyntaxKind.NumericLiteralExpression, bodyBuilder.Type switch
                 {
                     TargetType.Byte => Literal((byte) _value),
                     TargetType.SByte => Literal((sbyte) _value),
@@ -54,9 +56,10 @@ namespace GenericMathsGenerator.ValueTypes
                     TargetType.Long => Literal((long) _value),
                     TargetType.Single => Literal((float) _value),
                     TargetType.Double => Literal((double) _value),
-                    _ => throw new ArgumentOutOfRangeException(nameof(targetType))
+                    _ => throw new ArgumentOutOfRangeException(nameof(bodyBuilder.Type))
                 }
             );
+        }
 
         public bool Equals(LiteralValue? other)
         {

--- a/src/Maths/Silk.NET.Maths.GenericsGenerator/ValueTypes/ParameterReferenceValue.cs
+++ b/src/Maths/Silk.NET.Maths.GenericsGenerator/ValueTypes/ParameterReferenceValue.cs
@@ -39,7 +39,7 @@ namespace GenericMathsGenerator
         public int Step => 0;
 
         public ExpressionSyntax BuildExpression
-            (ImmutableArray<ExpressionSyntax> children, ref List<StatementSyntax> statements, TargetType targetType)
+            (IBodyBuilder bodyBuilder, ImmutableArray<ExpressionSyntax> children)
         {
             return SyntaxFactory.IdentifierName(ParameterName);
         }

--- a/src/Maths/Silk.NET.Maths.GenericsGenerator/ValueTypes/PropertyReferenceValue.cs
+++ b/src/Maths/Silk.NET.Maths.GenericsGenerator/ValueTypes/PropertyReferenceValue.cs
@@ -35,7 +35,8 @@ namespace GenericMathsGenerator.ValueTypes
 
         public int Step => 0;
 
-        public ExpressionSyntax BuildExpression(ImmutableArray<ExpressionSyntax> children, ref List<StatementSyntax> statements, TargetType type)
+        public ExpressionSyntax BuildExpression
+            (IBodyBuilder bodyBuilder, ImmutableArray<ExpressionSyntax> children)
         {
             return CastExpression(PredefinedType(Token(SyntaxKind.ObjectKeyword)), IdentifierName(Name));
         }

--- a/src/Maths/Silk.NET.Maths.GenericsGenerator/ValueTypes/UnaryOperatorValue.cs
+++ b/src/Maths/Silk.NET.Maths.GenericsGenerator/ValueTypes/UnaryOperatorValue.cs
@@ -33,7 +33,7 @@ namespace GenericMathsGenerator
 
         public int Step => _step.Value;
         public ExpressionSyntax BuildExpression
-            (ImmutableArray<ExpressionSyntax> children, ref List<StatementSyntax> statements, TargetType targetType)
+            (IBodyBuilder bodyBuilder, ImmutableArray<ExpressionSyntax> children)
         {
             Debug.Assert(children.Length == 1);
             return SyntaxFactory.PrefixUnaryExpression(OpSyntaxKind, children[0]);


### PR DESCRIPTION
This PR will introduce Type specialization, which will transform code like:
```cs
public struct TypeSpecialization
{
    public float Field;
    public float Property { get; set; }

    public float Method()
    {
        var a = Field + Property;
        var b = 5 + 5;
        var c = a + b;
        return c * c;
    }
}
```
into
```cs
public struct TypeSpecialization<T> where T : unmanaged
{
    public T Field;
    public T Property { get; set; }

    public T Method()
    {
        if (typeof(T) == typeof(byte)) return (byte)(object)((TypeSpecialization_Byte)(object)this).Method();
        else if ...
    }
}

public struct TypeSpecialization_Byte
{
    public byte Field;
    public byte Property { get; set; }

    public byte Method()
    {
        // same code produced when specializing just that method for byte.
    }
}
```

In a future PR options will be introduced for both types and methods to not generate as many methods with many options. This is outside of the scope of this PR.