### PR TITLE
[WIP] Generic Type generalization

### DIFF
--- a/src/Maths/Silk.NET.Maths.GenericsGenerator/Generator.cs
+++ b/src/Maths/Silk.NET.Maths.GenericsGenerator/Generator.cs
@@ -150,26 +150,32 @@ namespace GenericMaths
                 foreach (var (tds, symbol, attribute) in types)
                     if (tds.Parent is NamespaceDeclarationSyntax nds)
                     {
-                        try
+                        Dictionary<TargetType, string> typeNames = TargetTypes.ToDictionary
+                            (x => x, x => tds.Identifier.Text + "_" + Enum.GetName(typeof(TargetType), x));
+                        foreach (var targetType in TargetTypes)
                         {
-                            var newType = SpecializeType(context, tds, TargetType.Int, genericParameter).WithIdentifier(Identifier(tds.Identifier.Text + "_Int"));
+                            try
+                            {
+                                var newType = SpecializeType(context, tds, targetType, genericParameter)
+                                    .WithIdentifier(Identifier(typeNames[targetType]));
 
-                            var newNamespace = nds.WithMembers(SingletonList<MemberDeclarationSyntax>(newType));
-                            newNamespace = nds.SyntaxTree.GetCompilationUnitRoot()
-                                .Usings.Aggregate
-                                (
-                                    newNamespace,
-                                    (current, usingDirectiveSyntax) => current.AddUsings(usingDirectiveSyntax)
-                                );
-                            var str = newNamespace.NormalizeWhitespace().ToFullString();
-                            var name = $"{tds.Identifier.Text}_Maths_{Guid.NewGuid()}.cs";
-                            Debugger.Break();
-                            File.WriteAllText(@"C:\SILK.NET\src\Lab\GenericMaths\" + name, str);
-                            context.AddSource(name, str);
-                        }
-                        catch (DiagnosticException ex)
-                        {
-                            context.ReportDiagnostic(ex.Diagnostic);
+                                var newNamespace = nds.WithMembers(SingletonList<MemberDeclarationSyntax>(newType));
+                                newNamespace = nds.SyntaxTree.GetCompilationUnitRoot()
+                                    .Usings.Aggregate
+                                    (
+                                        newNamespace,
+                                        (current, usingDirectiveSyntax) => current.AddUsings(usingDirectiveSyntax)
+                                    );
+                                var str = newNamespace.NormalizeWhitespace().ToFullString();
+                                var name = $"{tds.Identifier.Text}_Maths_{typeNames[targetType]}_{Guid.NewGuid()}.cs";
+                                Debugger.Break();
+                                File.WriteAllText(@"C:\SILK.NET\src\Lab\GenericMaths\" + name, str);
+                                context.AddSource(name, str);
+                            }
+                            catch (DiagnosticException ex)
+                            {
+                                context.ReportDiagnostic(ex.Diagnostic);
+                            }
                         }
                     }
             }


### PR DESCRIPTION
This PR introduces the capability to generate a generic "helper" type for specialized types like so:
From:
```cs
[GenericMaths]
public struct TypeSpecialization
{
    public float Field;
    public float Property { get; set; }

    public float Method()
    {
        var a = Field + Property;
        var b = 5 + 5;
        var c = a + b;
        return c * c;
    }
}
```
to
```cs
public struct TypeSpecialization<T> where T : unmanaged
{
    public T Field;
    public T Property { get; set; }

    private void ThrowHelper() => throw new InvalidOperationException("..."); // Name is of course UB
    public T Method()
    {
        if (typeof(T) == typeof(byte)) return Method_S_Byte();
        // ...
        else if (typeof(T) == typeof(double)) return Method_S_Double();
        else { ThrowHelper(); return default(T); }
    }

   // Specialized methods
}
```