### PR TITLE
Language Version 9.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.100-rc.1.20452.10
+        dotnet-version: 5.0.100-rc.2.20479.15
     - name: Test
       run: dotnet test --verbosity normal
     - name: Pack

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.100-rc.1.20452.10
+        dotnet-version: 5.0.100-rc.2.20479.15
     - name: Install dependencies
       run: dotnet restore
     - name: Pack

--- a/build/props/common.props
+++ b/build/props/common.props
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <PackageIconUrl>https://static.ultz.co.uk/img/SilkDotNet.png</PackageIconUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <LangVersion>preview</LangVersion>
+        <LangVersion>9.0</LangVersion>
         <PackageReleaseNotes>
             Includes everything from the last previews, as well as:
             - SDL bindings

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100-rc.1.20452.10",
+    "version": "5.0.100-rc.2.20479.15",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Assimp/Silk.NET.Assimp/Silk.NET.Assimp.csproj
+++ b/src/Assimp/Silk.NET.Assimp/Silk.NET.Assimp.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
     
   <ItemGroup>

--- a/src/Core/Silk.NET.BuildTools/Bind/ProfileWriter.cs
+++ b/src/Core/Silk.NET.BuildTools/Bind/ProfileWriter.cs
@@ -712,7 +712,7 @@ namespace Silk.NET.BuildTools.Bind
             csproj.WriteLine("  <PropertyGroup>");
             csproj.WriteLine("    <TargetFramework>netstandard2.0</TargetFramework>");
             csproj.WriteLine("    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>");
-            csproj.WriteLine("    <LangVersion>preview</LangVersion>");
+            csproj.WriteLine("    <LangVersion>9.0</LangVersion>");
             csproj.WriteLine("  </PropertyGroup>");
             csproj.WriteLine();
             csproj.WriteLine("  <ItemGroup>");

--- a/src/Core/Silk.NET.Core/Silk.NET.Core.csproj
+++ b/src/Core/Silk.NET.Core/Silk.NET.Core.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <LangVersion>preview</LangVersion>
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Lab/TestLib/TestLib.csproj
+++ b/src/Lab/TestLib/TestLib.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <LangVersion>preview</LangVersion>
+        <LangVersion>9.0</LangVersion>
     </PropertyGroup>
 
     <Import Project="..\..\..\build\props\bindings.props" />

--- a/src/Lab/Triangle/Triangle.csproj
+++ b/src/Lab/Triangle/Triangle.csproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp3</TargetFramework>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <LangVersion>preview</LangVersion>
+        <LangVersion>9.0</LangVersion>
         <RuntimeIdentifiers Condition="'$(RuntimeIdentifiers)' == ''">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifiers>
     </PropertyGroup>
 

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Creative/Silk.NET.OpenAL.Extensions.Creative.csproj
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Creative/Silk.NET.OpenAL.Extensions.Creative.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/Silk.NET.OpenAL.Extensions.EXT.csproj
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.EXT/Silk.NET.OpenAL.Extensions.EXT.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Enumeration/Silk.NET.OpenAL.Extensions.Enumeration.csproj
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Enumeration/Silk.NET.OpenAL.Extensions.Enumeration.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/Silk.NET.OpenAL.Extensions.Soft.csproj
+++ b/src/OpenAL/Extensions/Silk.NET.OpenAL.Extensions.Soft/Silk.NET.OpenAL.Extensions.Soft.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenAL/Silk.NET.OpenAL/Silk.NET.OpenAL.csproj
+++ b/src/OpenAL/Silk.NET.OpenAL/Silk.NET.OpenAL.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netstandard20</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Deterministic>true</Deterministic>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.AMD/Silk.NET.OpenCL.Extensions.AMD.csproj
+++ b/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.AMD/Silk.NET.OpenCL.Extensions.AMD.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.APPLE/Silk.NET.OpenCL.Extensions.APPLE.csproj
+++ b/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.APPLE/Silk.NET.OpenCL.Extensions.APPLE.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.ARM/Silk.NET.OpenCL.Extensions.ARM.csproj
+++ b/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.ARM/Silk.NET.OpenCL.Extensions.ARM.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.EXT/Silk.NET.OpenCL.Extensions.EXT.csproj
+++ b/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.EXT/Silk.NET.OpenCL.Extensions.EXT.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.IMG/Silk.NET.OpenCL.Extensions.IMG.csproj
+++ b/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.IMG/Silk.NET.OpenCL.Extensions.IMG.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.INTEL/Silk.NET.OpenCL.Extensions.INTEL.csproj
+++ b/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.INTEL/Silk.NET.OpenCL.Extensions.INTEL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.KHR/Silk.NET.OpenCL.Extensions.KHR.csproj
+++ b/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.KHR/Silk.NET.OpenCL.Extensions.KHR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.NV/Silk.NET.OpenCL.Extensions.NV.csproj
+++ b/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.NV/Silk.NET.OpenCL.Extensions.NV.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.QCOM/Silk.NET.OpenCL.Extensions.QCOM.csproj
+++ b/src/OpenCL/Extensions/Silk.NET.OpenCL.Extensions.QCOM/Silk.NET.OpenCL.Extensions.QCOM.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenCL/Silk.NET.OpenCL/Silk.NET.OpenCL.csproj
+++ b/src/OpenCL/Silk.NET.OpenCL/Silk.NET.OpenCL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.AMD/Silk.NET.OpenGL.Extensions.AMD.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.AMD/Silk.NET.OpenGL.Extensions.AMD.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.APPLE/Silk.NET.OpenGL.Extensions.APPLE.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.APPLE/Silk.NET.OpenGL.Extensions.APPLE.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.ARB/Silk.NET.OpenGL.Extensions.ARB.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.ARB/Silk.NET.OpenGL.Extensions.ARB.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.EXT/Silk.NET.OpenGL.Extensions.EXT.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.EXT/Silk.NET.OpenGL.Extensions.EXT.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.INTEL/Silk.NET.OpenGL.Extensions.INTEL.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.INTEL/Silk.NET.OpenGL.Extensions.INTEL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.KHR/Silk.NET.OpenGL.Extensions.KHR.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.KHR/Silk.NET.OpenGL.Extensions.KHR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.MESA/Silk.NET.OpenGL.Extensions.MESA.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.MESA/Silk.NET.OpenGL.Extensions.MESA.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.NV/Silk.NET.OpenGL.Extensions.NV.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.NV/Silk.NET.OpenGL.Extensions.NV.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.OVR/Silk.NET.OpenGL.Extensions.OVR.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Extensions.OVR/Silk.NET.OpenGL.Extensions.OVR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.AMD/Silk.NET.OpenGL.Legacy.Extensions.AMD.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.AMD/Silk.NET.OpenGL.Legacy.Extensions.AMD.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.APPLE/Silk.NET.OpenGL.Legacy.Extensions.APPLE.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.APPLE/Silk.NET.OpenGL.Legacy.Extensions.APPLE.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.ARB/Silk.NET.OpenGL.Legacy.Extensions.ARB.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.ARB/Silk.NET.OpenGL.Legacy.Extensions.ARB.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.ATI/Silk.NET.OpenGL.Legacy.Extensions.ATI.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.ATI/Silk.NET.OpenGL.Legacy.Extensions.ATI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.EXT/Silk.NET.OpenGL.Legacy.Extensions.EXT.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.EXT/Silk.NET.OpenGL.Legacy.Extensions.EXT.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.GL3DFX/Silk.NET.OpenGL.Legacy.Extensions.GL3DFX.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.GL3DFX/Silk.NET.OpenGL.Legacy.Extensions.GL3DFX.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.GREMEDY/Silk.NET.OpenGL.Legacy.Extensions.GREMEDY.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.GREMEDY/Silk.NET.OpenGL.Legacy.Extensions.GREMEDY.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.HP/Silk.NET.OpenGL.Legacy.Extensions.HP.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.HP/Silk.NET.OpenGL.Legacy.Extensions.HP.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.IBM/Silk.NET.OpenGL.Legacy.Extensions.IBM.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.IBM/Silk.NET.OpenGL.Legacy.Extensions.IBM.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.INGR/Silk.NET.OpenGL.Legacy.Extensions.INGR.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.INGR/Silk.NET.OpenGL.Legacy.Extensions.INGR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.INTEL/Silk.NET.OpenGL.Legacy.Extensions.INTEL.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.INTEL/Silk.NET.OpenGL.Legacy.Extensions.INTEL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.KHR/Silk.NET.OpenGL.Legacy.Extensions.KHR.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.KHR/Silk.NET.OpenGL.Legacy.Extensions.KHR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.MESA/Silk.NET.OpenGL.Legacy.Extensions.MESA.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.MESA/Silk.NET.OpenGL.Legacy.Extensions.MESA.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.MESAX/Silk.NET.OpenGL.Legacy.Extensions.MESAX.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.MESAX/Silk.NET.OpenGL.Legacy.Extensions.MESAX.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.NV/Silk.NET.OpenGL.Legacy.Extensions.NV.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.NV/Silk.NET.OpenGL.Legacy.Extensions.NV.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.NVX/Silk.NET.OpenGL.Legacy.Extensions.NVX.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.NVX/Silk.NET.OpenGL.Legacy.Extensions.NVX.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.OES/Silk.NET.OpenGL.Legacy.Extensions.OES.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.OES/Silk.NET.OpenGL.Legacy.Extensions.OES.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.OML/Silk.NET.OpenGL.Legacy.Extensions.OML.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.OML/Silk.NET.OpenGL.Legacy.Extensions.OML.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.OVR/Silk.NET.OpenGL.Legacy.Extensions.OVR.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.OVR/Silk.NET.OpenGL.Legacy.Extensions.OVR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.PGI/Silk.NET.OpenGL.Legacy.Extensions.PGI.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.PGI/Silk.NET.OpenGL.Legacy.Extensions.PGI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.REND/Silk.NET.OpenGL.Legacy.Extensions.REND.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.REND/Silk.NET.OpenGL.Legacy.Extensions.REND.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.S3/Silk.NET.OpenGL.Legacy.Extensions.S3.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.S3/Silk.NET.OpenGL.Legacy.Extensions.S3.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.SGI/Silk.NET.OpenGL.Legacy.Extensions.SGI.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.SGI/Silk.NET.OpenGL.Legacy.Extensions.SGI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.SGIS/Silk.NET.OpenGL.Legacy.Extensions.SGIS.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.SGIS/Silk.NET.OpenGL.Legacy.Extensions.SGIS.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.SGIX/Silk.NET.OpenGL.Legacy.Extensions.SGIX.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.SGIX/Silk.NET.OpenGL.Legacy.Extensions.SGIX.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.SUN/Silk.NET.OpenGL.Legacy.Extensions.SUN.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.SUN/Silk.NET.OpenGL.Legacy.Extensions.SUN.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.SUNX/Silk.NET.OpenGL.Legacy.Extensions.SUNX.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.SUNX/Silk.NET.OpenGL.Legacy.Extensions.SUNX.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.WIN/Silk.NET.OpenGL.Legacy.Extensions.WIN.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGL.Legacy.Extensions.WIN/Silk.NET.OpenGL.Legacy.Extensions.WIN.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.AMD/Silk.NET.OpenGLES.Extensions.AMD.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.AMD/Silk.NET.OpenGLES.Extensions.AMD.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.ANDROID/Silk.NET.OpenGLES.Extensions.ANDROID.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.ANDROID/Silk.NET.OpenGLES.Extensions.ANDROID.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.ANGLE/Silk.NET.OpenGLES.Extensions.ANGLE.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.ANGLE/Silk.NET.OpenGLES.Extensions.ANGLE.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.APPLE/Silk.NET.OpenGLES.Extensions.APPLE.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.APPLE/Silk.NET.OpenGLES.Extensions.APPLE.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.ARM/Silk.NET.OpenGLES.Extensions.ARM.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.ARM/Silk.NET.OpenGLES.Extensions.ARM.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.DMP/Silk.NET.OpenGLES.Extensions.DMP.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.DMP/Silk.NET.OpenGLES.Extensions.DMP.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.EXT/Silk.NET.OpenGLES.Extensions.EXT.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.EXT/Silk.NET.OpenGLES.Extensions.EXT.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.FJ/Silk.NET.OpenGLES.Extensions.FJ.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.FJ/Silk.NET.OpenGLES.Extensions.FJ.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.IMG/Silk.NET.OpenGLES.Extensions.IMG.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.IMG/Silk.NET.OpenGLES.Extensions.IMG.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.INTEL/Silk.NET.OpenGLES.Extensions.INTEL.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.INTEL/Silk.NET.OpenGLES.Extensions.INTEL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.KHR/Silk.NET.OpenGLES.Extensions.KHR.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.KHR/Silk.NET.OpenGLES.Extensions.KHR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.MESA/Silk.NET.OpenGLES.Extensions.MESA.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.MESA/Silk.NET.OpenGLES.Extensions.MESA.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.NV/Silk.NET.OpenGLES.Extensions.NV.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.NV/Silk.NET.OpenGLES.Extensions.NV.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.OES/Silk.NET.OpenGLES.Extensions.OES.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.OES/Silk.NET.OpenGLES.Extensions.OES.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.OVR/Silk.NET.OpenGLES.Extensions.OVR.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.OVR/Silk.NET.OpenGLES.Extensions.OVR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.QCOM/Silk.NET.OpenGLES.Extensions.QCOM.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.QCOM/Silk.NET.OpenGLES.Extensions.QCOM.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.VIV/Silk.NET.OpenGLES.Extensions.VIV.csproj
+++ b/src/OpenGL/Extensions/Silk.NET.OpenGLES.Extensions.VIV/Silk.NET.OpenGLES.Extensions.VIV.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Silk.NET.OpenGL.Legacy/Silk.NET.OpenGL.Legacy.csproj
+++ b/src/OpenGL/Silk.NET.OpenGL.Legacy/Silk.NET.OpenGL.Legacy.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Silk.NET.OpenGL/Silk.NET.OpenGL.csproj
+++ b/src/OpenGL/Silk.NET.OpenGL/Silk.NET.OpenGL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenGL/Silk.NET.OpenGLES/Silk.NET.OpenGLES.csproj
+++ b/src/OpenGL/Silk.NET.OpenGLES/Silk.NET.OpenGLES.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <Import Project="..\..\..\build\props\bindings.props" />

--- a/src/OpenXR/Extensions/Silk.NET.OpenXR.Extensions.EXT/Silk.NET.OpenXR.Extensions.EXT.csproj
+++ b/src/OpenXR/Extensions/Silk.NET.OpenXR.Extensions.EXT/Silk.NET.OpenXR.Extensions.EXT.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenXR/Extensions/Silk.NET.OpenXR.Extensions.KHR/Silk.NET.OpenXR.Extensions.KHR.csproj
+++ b/src/OpenXR/Extensions/Silk.NET.OpenXR.Extensions.KHR/Silk.NET.OpenXR.Extensions.KHR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenXR/Extensions/Silk.NET.OpenXR.Extensions.MSFT/Silk.NET.OpenXR.Extensions.MSFT.csproj
+++ b/src/OpenXR/Extensions/Silk.NET.OpenXR.Extensions.MSFT/Silk.NET.OpenXR.Extensions.MSFT.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/OpenXR/Silk.NET.OpenXR/Silk.NET.OpenXR.csproj
+++ b/src/OpenXR/Silk.NET.OpenXR/Silk.NET.OpenXR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.AMD/Silk.NET.Vulkan.Extensions.AMD.csproj
+++ b/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.AMD/Silk.NET.Vulkan.Extensions.AMD.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.ANDROID/Silk.NET.Vulkan.Extensions.ANDROID.csproj
+++ b/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.ANDROID/Silk.NET.Vulkan.Extensions.ANDROID.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.EXT/Silk.NET.Vulkan.Extensions.EXT.csproj
+++ b/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.EXT/Silk.NET.Vulkan.Extensions.EXT.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.FUCHSIA/Silk.NET.Vulkan.Extensions.FUCHSIA.csproj
+++ b/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.FUCHSIA/Silk.NET.Vulkan.Extensions.FUCHSIA.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.GGP/Silk.NET.Vulkan.Extensions.GGP.csproj
+++ b/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.GGP/Silk.NET.Vulkan.Extensions.GGP.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.GOOGLE/Silk.NET.Vulkan.Extensions.GOOGLE.csproj
+++ b/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.GOOGLE/Silk.NET.Vulkan.Extensions.GOOGLE.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.INTEL/Silk.NET.Vulkan.Extensions.INTEL.csproj
+++ b/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.INTEL/Silk.NET.Vulkan.Extensions.INTEL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.KHR/Silk.NET.Vulkan.Extensions.KHR.csproj
+++ b/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.KHR/Silk.NET.Vulkan.Extensions.KHR.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.MVK/Silk.NET.Vulkan.Extensions.MVK.csproj
+++ b/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.MVK/Silk.NET.Vulkan.Extensions.MVK.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.NN/Silk.NET.Vulkan.Extensions.NN.csproj
+++ b/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.NN/Silk.NET.Vulkan.Extensions.NN.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.NV/Silk.NET.Vulkan.Extensions.NV.csproj
+++ b/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.NV/Silk.NET.Vulkan.Extensions.NV.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.NVX/Silk.NET.Vulkan.Extensions.NVX.csproj
+++ b/src/Vulkan/Extensions/Silk.NET.Vulkan.Extensions.NVX/Silk.NET.Vulkan.Extensions.NVX.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Vulkan/Silk.NET.Vulkan/Silk.NET.Vulkan.csproj
+++ b/src/Vulkan/Silk.NET.Vulkan/Silk.NET.Vulkan.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Windowing/Silk.NET.SDL/Silk.NET.SDL.csproj
+++ b/src/Windowing/Silk.NET.SDL/Silk.NET.SDL.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
C# 9 is go live now.
This PR replaces all preview usages with 9.0 which should now be equivalent.