### PR TITLE
Bug fixes and Improvements to Vk and XR.

### DIFF
--- a/src/Lab/VulkanTriangle/HelloTriangleApplication.cs
+++ b/src/Lab/VulkanTriangle/HelloTriangleApplication.cs
@@ -4,9 +4,11 @@
 // of the MIT license. See the LICENSE file for details.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Silk.NET.Core;
 using Silk.NET.Core.Native;
@@ -175,37 +177,37 @@ namespace VulkanTriangle
         {
             for (var i = 0; i < MaxFramesInFlight; i++)
             {
-                _vk.DestroySemaphore(_device, _renderFinishedSemaphores[i], (AllocationCallbacks*) null);
-                _vk.DestroySemaphore(_device, _imageAvailableSemaphores[i], (AllocationCallbacks*) null);
-                _vk.DestroyFence(_device, _inFlightFences[i], (AllocationCallbacks*) null);
+                _vk.DestroySemaphore(_device, _renderFinishedSemaphores[i], null);
+                _vk.DestroySemaphore(_device, _imageAvailableSemaphores[i], null);
+                _vk.DestroyFence(_device, _inFlightFences[i], null);
             }
 
-            _vk.DestroyCommandPool(_device, _commandPool, (AllocationCallbacks*) null);
+            _vk.DestroyCommandPool(_device, _commandPool, null);
 
             foreach (var framebuffer in _swapchainFramebuffers)
             {
-                _vk.DestroyFramebuffer(_device, framebuffer, (AllocationCallbacks*) null);
+                _vk.DestroyFramebuffer(_device, framebuffer, null);
             }
 
-            _vk.DestroyPipeline(_device, _graphicsPipeline, (AllocationCallbacks*) null);
-            _vk.DestroyPipelineLayout(_device, _pipelineLayout, (AllocationCallbacks*) null);
-            _vk.DestroyRenderPass(_device, _renderPass, (AllocationCallbacks*) null);
+            _vk.DestroyPipeline(_device, _graphicsPipeline, null);
+            _vk.DestroyPipelineLayout(_device, _pipelineLayout, null);
+            _vk.DestroyRenderPass(_device, _renderPass, null);
 
             foreach (var imageView in _swapchainImageViews)
             {
-                _vk.DestroyImageView(_device, imageView, (AllocationCallbacks*) null);
+                _vk.DestroyImageView(_device, imageView, null);
             }
 
-            _vkSwapchain.DestroySwapchain(_device, _swapchain, (AllocationCallbacks*) null);
-            _vk.DestroyDevice(_device, (AllocationCallbacks*) null);
+            _vkSwapchain.DestroySwapchain(_device, _swapchain, null);
+            _vk.DestroyDevice(_device, null);
 
             if (EnableValidationLayers)
             {
-                _debugUtils.DestroyDebugUtilsMessenger(_instance, _debugMessenger, (AllocationCallbacks*) null);
+                _debugUtils.DestroyDebugUtilsMessenger(_instance, _debugMessenger, null);
             }
 
-            _vkSurface.DestroySurface(_instance, _surface, (AllocationCallbacks*) null);
-            _vk.DestroyInstance(_instance, (AllocationCallbacks*) null);
+            _vkSurface.DestroySurface(_instance, _surface, null);
+            _vk.DestroyInstance(_instance, null);
         }
 
         private unsafe void CreateInstance()
@@ -233,8 +235,8 @@ namespace VulkanTriangle
                 PApplicationInfo = &appInfo
             };
 
-            var extensions = (byte**) _window.VkSurface!.GetRequiredExtensions(out var extCount);
-            var newExtensions = stackalloc byte*[(int)(extCount + _instanceExtensions.Length)];
+            var extensions = _window.VkSurface!.GetRequiredExtensions(out var extCount);
+            var newExtensions = stackalloc byte*[(int) (extCount + _instanceExtensions.Length)];
             for (var i = 0; i < extCount; i++)
             {
                 newExtensions[i] = extensions[i];
@@ -269,12 +271,12 @@ namespace VulkanTriangle
             }
 
             _vk.CurrentInstance = _instance;
-            
+
             if (!_vk.TryGetInstanceExtension(_instance, out _vkSurface))
             {
                 throw new NotSupportedException("KHR_surface extension not found.");
             }
-            
+
             Marshal.FreeHGlobal((IntPtr) appInfo.PApplicationName);
             Marshal.FreeHGlobal((IntPtr) appInfo.PEngineName);
 
@@ -334,138 +336,128 @@ namespace VulkanTriangle
 
         private unsafe void PickPhysicalDevice()
         {
-            var deviceCount = 0u;
-            _vk.EnumeratePhysicalDevices(_instance, &deviceCount, (PhysicalDevice*) null);
+            var devices = _vk.GetPhysicalDevices(_instance);
 
-            if (deviceCount == 0)
+            if (!devices.Any())
             {
                 throw new NotSupportedException("Failed to find GPUs with Vulkan support.");
             }
 
-            var devices = stackalloc PhysicalDevice[(int) deviceCount];
-            _vk.EnumeratePhysicalDevices(_instance, &deviceCount, devices);
-
-            for (var i = 0; i < deviceCount; i++)
+            _physicalDevice = devices.FirstOrDefault(device =>
             {
-                var device = devices[i];
-                if (IsDeviceSuitable(device))
+                var indices = FindQueueFamilies(device);
+
+                var extensionsSupported = CheckDeviceExtensionSupport(device);
+
+                var swapChainAdequate = false;
+                if (extensionsSupported)
                 {
-                    _physicalDevice = device;
-                    return;
+                    var swapChainSupport = QuerySwapChainSupport(device);
+                    swapChainAdequate = swapChainSupport.Formats.Length != 0 && swapChainSupport.PresentModes.Length != 0;
                 }
-            }
 
-            throw new Exception("No suitable device.");
+                return indices.IsComplete() && extensionsSupported && swapChainAdequate;
+            });
+
+            if (_physicalDevice.Handle == IntPtr.Zero)
+                throw new Exception("No suitable device.");
         }
 
-        private bool IsDeviceSuitable(PhysicalDevice device)
-        {
-            var indices = FindQueueFamilies(device);
-
-            var extensionsSupported = CheckDeviceExtensionSupport(device);
-
-            var swapChainAdequate = false;
-            if (extensionsSupported)
-            {
-                var swapChainSupport = QuerySwapChainSupport(device);
-                swapChainAdequate = swapChainSupport.Formats.Length != 0 && swapChainSupport.PresentModes.Length != 0;
-            }
-
-            return indices.IsComplete() && extensionsSupported && swapChainAdequate;
-        }
-
+        private static readonly ConcurrentDictionary<PhysicalDevice, SwapChainSupportDetails> _swapChainSupportDetailsCache
+            = new ConcurrentDictionary<PhysicalDevice, SwapChainSupportDetails>();
         private unsafe SwapChainSupportDetails QuerySwapChainSupport(PhysicalDevice device)
         {
-            var details = new SwapChainSupportDetails();
-            _vkSurface.GetPhysicalDeviceSurfaceCapabilities(device, _surface, out var surfaceCapabilities);
-            details.Capabilities = surfaceCapabilities;
-
-            var formatCount = 0u;
-            _vkSurface.GetPhysicalDeviceSurfaceFormats(device, _surface, &formatCount, (SurfaceFormatKHR*) null);
-
-            if (formatCount != 0)
+            return _swapChainSupportDetailsCache.GetOrAdd(device, d =>
             {
-                details.Formats = new SurfaceFormatKHR[formatCount];
-                var formats = stackalloc SurfaceFormatKHR[(int) formatCount];
-                _vkSurface.GetPhysicalDeviceSurfaceFormats(device, _surface, &formatCount, formats);
+                var details = new SwapChainSupportDetails();
+                _vkSurface.GetPhysicalDeviceSurfaceCapabilities(d, _surface, out var surfaceCapabilities);
+                details.Capabilities = surfaceCapabilities;
 
-                for (var i = 0; i < formatCount; i++)
+                var formatCount = 0u;
+                _vkSurface.GetPhysicalDeviceSurfaceFormats(d, _surface, &formatCount, null);
+
+                if (formatCount != 0)
                 {
-                    details.Formats[i] = formats[i];
+                    details.Formats = new SurfaceFormatKHR[formatCount];
+
+                    using var mem = GlobalMemory.Allocate((int) formatCount * sizeof(SurfaceFormatKHR));
+                    var formats = (SurfaceFormatKHR*) Unsafe.AsPointer(ref mem.GetPinnableReference());
+
+                    _vkSurface.GetPhysicalDeviceSurfaceFormats(d, _surface, &formatCount, formats);
+
+                    for (var i = 0; i < formatCount; i++)
+                    {
+                        details.Formats[i] = formats[i];
+                    }
                 }
-            }
 
-            var presentModeCount = 0u;
-            _vkSurface.GetPhysicalDeviceSurfacePresentModes(device, _surface, &presentModeCount, (PresentModeKHR*) null);
+                var presentModeCount = 0u;
+                _vkSurface.GetPhysicalDeviceSurfacePresentModes(d, _surface, &presentModeCount, null);
 
-            if (presentModeCount != 0)
-            {
-                details.PresentModes = new PresentModeKHR[presentModeCount];
-                var modes = stackalloc PresentModeKHR[(int) presentModeCount];
-                _vkSurface.GetPhysicalDeviceSurfacePresentModes(device, _surface, &presentModeCount, modes);
-
-                for (var i = 0; i < presentModeCount; i++)
+                if (presentModeCount != 0)
                 {
-                    details.PresentModes[i] = modes[i];
-                }
-            }
+                    details.PresentModes = new PresentModeKHR[presentModeCount];
 
-            return details;
+                    using var mem = GlobalMemory.Allocate((int) presentModeCount * sizeof(PresentModeKHR));
+                    var modes = (PresentModeKHR*) Unsafe.AsPointer(ref mem.GetPinnableReference());
+
+                    _vkSurface.GetPhysicalDeviceSurfacePresentModes(d, _surface, &presentModeCount, modes);
+
+                    for (var i = 0; i < presentModeCount; i++)
+                    {
+                        details.PresentModes[i] = modes[i];
+                    }
+                }
+
+                return details;
+            });
         }
 
         private unsafe bool CheckDeviceExtensionSupport(PhysicalDevice device)
         {
-            uint extensionCount;
-            _vk.EnumerateDeviceExtensionProperties(device, (byte*) null, &extensionCount, (ExtensionProperties*) null);
-
-            var availableExtensions = stackalloc ExtensionProperties[(int) extensionCount];
-            _vk.EnumerateDeviceExtensionProperties(device, (byte*) null, &extensionCount, availableExtensions);
-
-            var requiredExtensions = new List<string>();
-            requiredExtensions.AddRange(_deviceExtensions);
-
-            for (var i = 0u; i < extensionCount; i++)
-            {
-                requiredExtensions.Remove(Marshal.PtrToStringAnsi((IntPtr) availableExtensions[i].ExtensionName));
-            }
-
-            return requiredExtensions.Count == 0;
+            return _deviceExtensions.All(ext => _vk.IsDeviceExtensionPresent(device, ext));
         }
 
+        private static readonly ConcurrentDictionary<PhysicalDevice, QueueFamilyIndices> _queueFamilyIndicesCache
+            = new ConcurrentDictionary<PhysicalDevice, QueueFamilyIndices>();
         private unsafe QueueFamilyIndices FindQueueFamilies(PhysicalDevice device)
         {
-            var indices = new QueueFamilyIndices();
-
-            uint queryFamilyCount = 0;
-            _vk.GetPhysicalDeviceQueueFamilyProperties(device, &queryFamilyCount, (QueueFamilyProperties*) null);
-
-            var queueFamilies = stackalloc QueueFamilyProperties[(int) queryFamilyCount];
-
-            _vk.GetPhysicalDeviceQueueFamilyProperties(device, &queryFamilyCount, queueFamilies);
-            for (var i = 0u; i < queryFamilyCount; i++)
+            return _queueFamilyIndicesCache.GetOrAdd(device, d =>
             {
-                var queueFamily = queueFamilies[i];
-                // note: HasFlag is slow on .NET Core 2.1 and below.
-                // if you're targeting these versions, use ((queueFamily.QueueFlags & QueueFlags.QueueGraphicsBit) != 0)
-                if (queueFamily.QueueFlags.HasFlag(QueueFlags.QueueGraphicsBit))
+                var indices = new QueueFamilyIndices();
+
+                uint queryFamilyCount = 0;
+                _vk.GetPhysicalDeviceQueueFamilyProperties(d, &queryFamilyCount, null);
+
+                using var mem = GlobalMemory.Allocate((int) queryFamilyCount * sizeof(QueueFamilyProperties));
+                var queueFamilies = (QueueFamilyProperties*) Unsafe.AsPointer(ref mem.GetPinnableReference());
+
+                _vk.GetPhysicalDeviceQueueFamilyProperties(d, &queryFamilyCount, queueFamilies);
+                for (var i = 0u; i < queryFamilyCount; i++)
                 {
-                    indices.GraphicsFamily = i;
+                    var queueFamily = queueFamilies[i];
+                    // note: HasFlag is slow on .NET Core 2.1 and below.
+                    // if you're targeting these versions, use ((queueFamily.QueueFlags & QueueFlags.QueueGraphicsBit) != 0)
+                    if (queueFamily.QueueFlags.HasFlag(QueueFlags.QueueGraphicsBit))
+                    {
+                        indices.GraphicsFamily = i;
+                    }
+
+                    _vkSurface.GetPhysicalDeviceSurfaceSupport(d, i, _surface, out var presentSupport);
+
+                    if (presentSupport == Vk.True)
+                    {
+                        indices.PresentFamily = i;
+                    }
+
+                    if (indices.IsComplete())
+                    {
+                        break;
+                    }
                 }
 
-                _vkSurface.GetPhysicalDeviceSurfaceSupport(device, i, _surface, out var presentSupport);
-
-                if (presentSupport == Vk.True)
-                {
-                    indices.PresentFamily = i;
-                }
-
-                if (indices.IsComplete())
-                {
-                    break;
-                }
-            }
-
-            return indices;
+                return indices;
+            });
         }
 
         public struct QueueFamilyIndices
@@ -607,7 +599,7 @@ namespace VulkanTriangle
                 {
                     throw new NotSupportedException("KHR_swapchain extension not found.");
                 }
-                
+
                 fixed (SwapchainKHR* swapchain = &_swapchain)
                 {
                     if (_vkSwapchain.CreateSwapchain(_device, &createInfo, null, swapchain) != Result.Success)
@@ -617,7 +609,7 @@ namespace VulkanTriangle
                 }
             }
 
-            _vkSwapchain.GetSwapchainImages(_device, _swapchain, &imageCount, (Image*) null);
+            _vkSwapchain.GetSwapchainImages(_device, _swapchain, &imageCount, null);
             _swapchainImages = new Image[imageCount];
             fixed (Image* swapchainImage = _swapchainImages)
             {
@@ -917,8 +909,8 @@ namespace VulkanTriangle
                 }
             }
 
-            _vk.DestroyShaderModule(_device, fragShaderModule, (AllocationCallbacks*) null);
-            _vk.DestroyShaderModule(_device, vertShaderModule, (AllocationCallbacks*) null);
+            _vk.DestroyShaderModule(_device, fragShaderModule, null);
+            _vk.DestroyShaderModule(_device, vertShaderModule, null);
         }
 
         private unsafe ShaderModule CreateShaderModule(byte[] code)

--- a/src/OpenXR/Silk.NET.OpenXR/XR.cs
+++ b/src/OpenXR/Silk.NET.OpenXR/XR.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Threading;
 using Silk.NET.Core;
 using Silk.NET.Core.Contexts;
 using Silk.NET.Core.Native;
@@ -16,17 +18,18 @@ namespace Silk.NET.OpenXR
         public Instance? CurrentInstance { get; set; }
         public static XR GetApi()
         {
-             var ret = new XR(CreateDefaultContext(new OpenXRLibraryNameContainer().GetLibraryName()));
-             return ret;
+            return new XR(CreateDefaultContext(new OpenXRLibraryNameContainer().GetLibraryName()));
         }
 
         [Obsolete("Use IsInstanceExtensionPresent instead.", true)]
         public override bool IsExtensionPresent(string extension) => IsInstanceExtensionPresent(null, extension);
-        private Dictionary<string, List<string>> _cachedInstanceExtensions = new Dictionary<string, List<string>>();
+        private readonly HashSet<string> _cachedInstanceExtensions = new HashSet<string>();
+        private readonly ReaderWriterLockSlim _cachedInstanceExtensionsLock = new ReaderWriterLockSlim();
 
         /// <summary>
         /// Attempts to load the given instance extension.
         /// </summary>
+        /// <param name="layer">The layer name.</param>
         /// <param name="instance">The instance to load the extension from.</param>
         /// <param name="ext">The loaded instance extension, or null if load failed.</param>
         /// <typeparam name="T">The instance extension to load.</typeparam>
@@ -35,9 +38,9 @@ namespace Silk.NET.OpenXR
         /// to call an extension function from an extension that isn't loaded.
         /// </remarks>
         /// <returns>Whether the extension is available and loaded.</returns>
-        public bool TryGetInstanceExtension<T>(string layer, Instance instance, out T ext) where T:NativeExtension<XR> =>
+        public bool TryGetInstanceExtension<T>(string layer, Instance instance, out T ext) where T : NativeExtension<XR> =>
             !((ext = IsInstanceExtensionPresent(layer, ExtensionAttribute.GetExtensionAttribute(typeof(T)).Name)
-                ? (T)Activator.CreateInstance
+                ? (T) Activator.CreateInstance
                     (typeof(T), new LamdaNativeContext(
                     x =>
                     {
@@ -55,49 +58,64 @@ namespace Silk.NET.OpenXR
         /// <summary>
         /// Checks whether the given instance extension is available.
         /// </summary>
+        /// <param name="layer">The layer name.</param>
         /// <param name="extension">The instance extension name.</param>
         /// <returns>Whether the instance extension is available.</returns>
         public unsafe bool IsInstanceExtensionPresent(string layer, string extension)
         {
+            // For a detailed explanation of the logic see Silk.Net.Vulkan.Vk.IsDeviceExtensionPresent
             layer ??= string.Empty;
-            if (_cachedInstanceExtensions.TryGetValue(layer, out var val))
-            {
-                return val.Contains(extension);
-            }
+            var layer_sep = layer + '\0';
+            var fullKey = layer_sep + extension;
+            var result = false;
 
-            var l = new List<string>();
-            if (string.IsNullOrWhiteSpace(layer))
+            _cachedInstanceExtensionsLock.EnterUpgradeableReadLock();
+            if (_cachedInstanceExtensions.Contains(fullKey))
             {
-                Add(l, null);
+                // We found the extension
+                result = true;
             }
-            else
+            else if (!_cachedInstanceExtensions.Contains(layer))
             {
+                // The lack of the device handle indicates we've not been previously initialised.  We now need a write lock.
+                _cachedInstanceExtensionsLock.EnterWriteLock();
+                GlobalMemory mem = null;
                 var layerName = SilkMarshal.StringToPtr(layer);
-                Add(l, (byte*) layerName);
-                SilkMarshal.Free(layerName);
+                try
+                {
+                    var extensionCount = 0u;
+                    EnumerateInstanceExtensionProperties((byte*) layerName, extensionCount, &extensionCount, null);
+
+                    mem = GlobalMemory.Allocate((int) extensionCount * sizeof(ExtensionProperties));
+                    var exts = (ExtensionProperties*) Unsafe.AsPointer(ref mem.GetPinnableReference());
+
+                    // TODO Is this necessary?
+                    for (int i = 0; i < extensionCount; i++)
+                    {
+                        exts[i] = new ExtensionProperties(StructureType.TypeExtensionProperties);
+                    }
+
+                    EnumerateInstanceExtensionProperties((byte*) layerName, extensionCount, &extensionCount, exts);
+                    for (var i = 0; i < extensionCount; i++)
+                    {
+                        var newKey = layer_sep + Marshal.PtrToStringAnsi((IntPtr) exts[i].ExtensionName);
+                        _cachedInstanceExtensions.Add(newKey);
+                        if (!result && string.Equals(newKey, fullKey))
+                        {
+                            result = true;
+                        }
+                    }
+                }
+                finally
+                {
+                    _cachedInstanceExtensionsLock.ExitWriteLock();
+                    SilkMarshal.Free(layerName);
+                    mem?.Dispose();
+                }
             }
 
-            _cachedInstanceExtensions[layer] = l;
-
-            return l.Contains(extension);
-        }
-
-        private unsafe void Add(ICollection<string> extensions, byte* layerName)
-        {
-            var extensionCount = 0u;
-            EnumerateInstanceExtensionProperties(layerName, extensionCount, &extensionCount, null);
-            var exts = stackalloc ExtensionProperties[(int)extensionCount];
-
-            for (int i = 0; i < extensionCount; i++)
-            {
-                exts[i] = new ExtensionProperties(StructureType.TypeExtensionProperties);
-            }
-            
-            EnumerateInstanceExtensionProperties(layerName, extensionCount, &extensionCount, exts);
-            for (var i = 0; i < extensionCount; i++)
-            {
-                extensions.Add(Marshal.PtrToStringAnsi((IntPtr) exts[i].ExtensionName));
-            }
+            _cachedInstanceExtensionsLock.ExitUpgradeableReadLock();
+            return result;
         }
     }
 }

--- a/src/OpenXR/Silk.NET.OpenXR/XR.cs
+++ b/src/OpenXR/Silk.NET.OpenXR/XR.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/src/Vulkan/Silk.NET.Vulkan/Vk.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/Vk.cs
@@ -300,7 +300,18 @@ namespace Silk.NET.Vulkan
         /// <returns>Whether the device extension is available.</returns>
         public unsafe bool IsDeviceExtensionPresent(Instance instance, string extension, out PhysicalDevice device)
         {
-            device = _cachedPhyscialDevices.GetOrAdd(instance, i =>
+            device = GetPhysicalDevices(instance).FirstOrDefault(pd => IsDeviceExtensionPresent(pd, extension));
+            return device.Handle != IntPtr.Zero;
+        }
+
+        /// <summary>
+        /// Gets all the physical devices for the instance.
+        /// </summary>
+        /// <param name="instance">The Vulkan instance to use.</param>
+        /// <returns>Whether the device extension is available.</returns>
+        public unsafe IReadOnlyCollection<PhysicalDevice> GetPhysicalDevices(Instance instance)
+        {
+            return _cachedPhyscialDevices.GetOrAdd(instance, i =>
             {
                 var physicalDeviceCount = 0u;
                 EnumeratePhysicalDevices(i, &physicalDeviceCount, null);
@@ -315,10 +326,7 @@ namespace Silk.NET.Vulkan
                     EnumeratePhysicalDevices(instance, &physicalDeviceCount, pdp);
                 }
                 return physicalDevices;
-
-            }).FirstOrDefault(pd => IsDeviceExtensionPresent(pd, extension));
-
-            return device.Handle != IntPtr.Zero;
+            });
         }
 
         /// <summary>

--- a/src/Vulkan/Silk.NET.Vulkan/Vk.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/Vk.cs
@@ -1,16 +1,14 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Unsafe = System.Runtime.CompilerServices.Unsafe;
 using Silk.NET.Core;
 using Silk.NET.Core.Attributes;
 using Silk.NET.Core.Contexts;
-using Silk.NET.Core.Loader;
 using Silk.NET.Core.Native;
-using LibraryLoader = Silk.NET.Core.Loader.LibraryLoader;
-using System.Collections.Concurrent;
+using Unsafe = System.Runtime.CompilerServices.Unsafe;
 
 namespace Silk.NET.Vulkan
 {

--- a/src/Vulkan/Silk.NET.Vulkan/Vk.cs
+++ b/src/Vulkan/Silk.NET.Vulkan/Vk.cs
@@ -228,6 +228,7 @@ namespace Silk.NET.Vulkan
             var prefix = device.Handle.ToString();
             var prefix_sep = prefix + '|';
             var fullKey = prefix_sep + extension;
+            var result = false;
 
             // We place a devices handle into the hashset to indicate it has been previously loaded.
             // We then prefix entries with '<Handle>|' which will never collide with '<Handle>' (which is an
@@ -242,7 +243,6 @@ namespace Silk.NET.Vulkan
             _cachedDeviceExtensionsLock.EnterUpgradeableReadLock();
 
             // We check for the extension first to avoid 2 lookups
-            var result = false;
             if (_cachedDeviceExtensions.Contains(fullKey))
             {
                 // We found the extension


### PR DESCRIPTION
# Summary of the PR
Updates `Vk` and `XR` classes to improve thread-safety, performance, and memory utilisation, whilst also removing a bug which would cause an 'infinite' loop when the number of extension properties exceeded 128.

Also adds `Vk.GetPhysicalDevices` to retrieve the cache of physical devices for an instance.

Updated `VulkanTriangles` to leverage API changes, and to review stack allocations.

# Related issues, Discord discussions, or proposals
The `VulkanTriangles` project was broken when accessing a device that had >128 extensions and would enter an 'infinite' loop allocating increasing amounts of memory until the application crashed.  It was also allocating large data structures (>1k) on the stack, which risksed stack overflows.

The resultant fixes re-worked the areas that caused these problems and are based on discussions on Discord.

# Further Comments
A full explanation of the code logic changes is included in `Vk.cs` in the comments.
