### PR TITLE
Fix elapsed time parameters on Window.Render and Update events

### DIFF
--- a/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
+++ b/src/Windowing/Silk.NET.Windowing.Common/Internals/ViewImplementationBase.cs
@@ -165,13 +165,14 @@ namespace Silk.NET.Windowing.Internals
                     _swapIntervalChanged = false;
                 }
 
-                Render?.Invoke(_renderStopwatch.Elapsed.TotalSeconds);
+                delta = _renderStopwatch.Elapsed.TotalSeconds;
+                _renderStopwatch.Restart();
+                Render?.Invoke(delta);
+
                 if (ShouldSwapAutomatically)
                 {
                     GLContext?.SwapBuffers();
                 }
-
-                _renderStopwatch.Restart();
             }
         }
 
@@ -180,8 +181,8 @@ namespace Silk.NET.Windowing.Internals
             var delta = _updateStopwatch.Elapsed.TotalSeconds;
             if (delta >= _updatePeriod)
             {
-                Update?.Invoke(_updateStopwatch.Elapsed.TotalSeconds);
                 _updateStopwatch.Restart();
+                Update?.Invoke(delta);
             }
         }
 


### PR DESCRIPTION
Fixes issue #394.

In summary, the stopwatches need to be restarted _before_ the events are invoked. Or really, stopwatches need to be restarted right after the elapsed time was taken. Otherwise, the time the invocation of the method took (and therefore the whole update/render logic the library user wrote) will not be counted as elapsed time on the next invocation.

If you store a double time that starts at 0 and each update add to it the elapsed time parameter, you'd now get nearly exactly the same as if you just used a stopwatch that was started on load, even if your Update method takes a very long time. Before this change, you'd see that your time variable would stay behind (this might not have been noticeable if your Update method is very fast).